### PR TITLE
Octopus Pack step

### DIFF
--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusPackPackageBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusPackPackageBuildProcess.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2000-2012 Octopus Deploy Pty. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package octopus.teamcity.agent;
+
+import jetbrains.buildServer.ExtensionHolder;
+import jetbrains.buildServer.RunBuildException;
+import jetbrains.buildServer.agent.*;
+import jetbrains.buildServer.agent.impl.artifacts.ArtifactsBuilder;
+import jetbrains.buildServer.agent.impl.artifacts.ArtifactsCollection;
+import jetbrains.buildServer.messages.serviceMessages.ServiceMessage;
+import octopus.teamcity.common.OctopusConstants;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class OctopusPackPackageBuildProcess extends OctopusBuildProcess {
+
+    protected final ExtensionHolder myExtensionHolder;
+    protected final AgentRunningBuild myRunningBuild;
+    protected List<ArtifactsCollection> artifactsCollections;
+
+    public OctopusPackPackageBuildProcess(@NotNull AgentRunningBuild runningBuild, @NotNull BuildRunnerContext context, @NotNull final ExtensionHolder extensionHolder) {
+       super(runningBuild, context);
+
+        myExtensionHolder = extensionHolder;
+        myRunningBuild = runningBuild;
+    }
+
+    @Override
+    protected String getLogMessage() {
+        return "Creating package";
+    }
+
+    @NotNull
+    @Override
+    public BuildFinishedStatus waitFor() throws RunBuildException {
+        BuildFinishedStatus status = super.waitFor();
+
+        final Map<String, String> parameters = getContext().getRunnerParameters();
+        final OctopusConstants constants = OctopusConstants.Instance;
+        final String packageId = parameters.get(constants.getPackageIdKey());
+        final String packageFormat = parameters.get(constants.getPackageFormatKey()).toLowerCase();
+        final String packageVersion = parameters.get(constants.getPackageVersionKey());
+        final String outputPath = parameters.get(constants.getPackageOutputPathKey());
+        final boolean publishArtifacts = Boolean.parseBoolean(parameters.get(constants.getPublishArtifactsKey()));
+
+        if (!publishArtifacts)
+            return status;
+
+        String packagePath = outputPath;
+        if (!packagePath.endsWith(File.separator))
+            packagePath += File.separator;
+        packagePath += packageId + "." + packageVersion + "." + packageFormat;
+
+        BuildProgressLogger logger = myRunningBuild.getBuildLogger();
+
+        String message = ServiceMessage.asString("publishArtifacts", myRunningBuild.getCheckoutDirectory() + File.separator + packagePath);
+        logger.message(message);
+
+        return status;
+    }
+
+    @Override
+    protected OctopusCommandBuilder createCommand() {
+        final Map<String, String> parameters = getContext().getRunnerParameters();
+        final OctopusConstants constants = OctopusConstants.Instance;
+
+        return new OctopusCommandBuilder() {
+            @Override
+            protected String[] buildCommand(boolean masked) {
+                final ArrayList<String> commands = new ArrayList<String>();
+                final String packageId = parameters.get(constants.getPackageIdKey());
+                final String packageFormat = parameters.get(constants.getPackageFormatKey()).toLowerCase();
+                final String packageVersion = parameters.get(constants.getPackageVersionKey());
+                final String sourcePath = parameters.get(constants.getPackageSourcePathKey());
+                final String outputPath = parameters.get(constants.getPackageOutputPathKey());
+                final String commandLineArguments = parameters.get(constants.getCommandLineArgumentsKey());
+
+                commands.add("pack");
+
+                commands.add("--id");
+                commands.add(packageId);
+
+                commands.add("--format");
+                commands.add(packageFormat);
+
+                commands.add("--version");
+                commands.add(packageVersion);
+
+                commands.add("--basePath");
+                commands.add(sourcePath);
+
+                commands.add("--outFolder");
+                commands.add(outputPath);
+
+                if (commandLineArguments != null && !commandLineArguments.isEmpty()) {
+                    commands.addAll(splitSpaceSeparatedValues(commandLineArguments));
+                }
+
+                return commands.toArray(new String[commands.size()]);
+            }
+        };
+    }
+}

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusPackPackageRunner.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusPackPackageRunner.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2000-2012 Octopus Deploy Pty. Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package octopus.teamcity.agent;
+
+import com.intellij.openapi.diagnostic.Logger;
+import jetbrains.buildServer.ExtensionHolder;
+import jetbrains.buildServer.RunBuildException;
+import jetbrains.buildServer.agent.*;
+import jetbrains.buildServer.log.Loggers;
+import octopus.teamcity.common.OctopusConstants;
+import org.jetbrains.annotations.NotNull;
+
+public class OctopusPackPackageRunner implements AgentBuildRunner {
+    private static final Logger LOG = Loggers.SERVER;
+    protected final ExtensionHolder myExtensionHolder;
+
+    public OctopusPackPackageRunner(@NotNull final ExtensionHolder extensionHolder) {
+        myExtensionHolder = extensionHolder;
+    }
+
+    @NotNull
+    public BuildProcess createBuildProcess(@NotNull AgentRunningBuild runningBuild, @NotNull BuildRunnerContext context) throws RunBuildException {
+        return new OctopusPackPackageBuildProcess(runningBuild, context, myExtensionHolder);
+    }
+
+    @NotNull
+    public AgentBuildRunnerInfo getRunnerInfo() {
+        return new AgentBuildRunnerInfo() {
+            @NotNull
+            public String getType() {
+                return OctopusConstants.PACK_PACKAGE_RUNNER_TYPE;
+            }
+
+            public boolean canRun(@NotNull BuildAgentConfiguration agentConfiguration) {
+                return OctopusOsUtils.CanRunOcto(agentConfiguration);
+            }
+        };
+    }
+}

--- a/octopus-agent/src/main/resources/META-INF/build-agent-plugin-Octopus.TeamCity.xml
+++ b/octopus-agent/src/main/resources/META-INF/build-agent-plugin-Octopus.TeamCity.xml
@@ -26,4 +26,5 @@
     <bean class="octopus.teamcity.agent.OctopusDeployReleaseRunner"/>
     <bean class="octopus.teamcity.agent.OctopusPromoteReleaseRunner"/>
     <bean class="octopus.teamcity.agent.OctopusPushPackageRunner"/>
+    <bean class="octopus.teamcity.agent.OctopusPackPackageRunner"/>
 </beans>

--- a/octopus-common/src/main/java/octopus/teamcity/common/OctopusConstants.java
+++ b/octopus-common/src/main/java/octopus/teamcity/common/OctopusConstants.java
@@ -75,6 +75,13 @@ public class OctopusConstants {
     public String getDeployToKey() { return "octopus_deployto"; }
     public String getTenantsKey() { return "octoups_tenants"; }
     public String getTenantTagsKey() { return "octoups_tenanttags"; }
+
+    public String getPackageIdKey() { return "octopus_packageid"; }
+    public String getPackageFormatKey() { return "octopus_packageformat"; }
+    public String getPackageVersionKey() { return "octopus_packageversion"; }
+    public String getPackageSourcePathKey() { return "octopus_packagesourcepath"; }
+    public String getPackageOutputPathKey() { return "octopus_packageoutputpath"; }
+
     public String getPackagePathsKey() {
         return "octopus_packagepaths";
     }
@@ -110,5 +117,6 @@ public class OctopusConstants {
     public static final String CREATE_RELEASE_RUNNER_TYPE = "octopus.create.release";
     public static final String DEPLOY_RELEASE_RUNNER_TYPE = "octopus.deploy.release";
     public static final String PROMOTE_RELEASE_RUNNER_TYPE = "octopus.promote.release";
+    public static final String PACK_PACKAGE_RUNNER_TYPE = "octopus.pack.package";
     public static final String PUSH_PACKAGE_RUNNER_TYPE = "octopus.push.package";
 }

--- a/octopus-server/src/main/java/octopus/teamcity/server/OctopusPackPackageRunType.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/OctopusPackPackageRunType.java
@@ -30,10 +30,10 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-public class OctopusPushPackageRunType extends RunType {
+public class OctopusPackPackageRunType extends RunType {
     private final PluginDescriptor pluginDescriptor;
 
-    public OctopusPushPackageRunType(final RunTypeRegistry runTypeRegistry, final PluginDescriptor pluginDescriptor) {
+    public OctopusPackPackageRunType(final RunTypeRegistry runTypeRegistry, final PluginDescriptor pluginDescriptor) {
         this.pluginDescriptor = pluginDescriptor;
         runTypeRegistry.registerRunType(this);
     }
@@ -41,17 +41,17 @@ public class OctopusPushPackageRunType extends RunType {
     @NotNull
     @Override
     public String getType() {
-        return OctopusConstants.PUSH_PACKAGE_RUNNER_TYPE;
+        return OctopusConstants.PACK_PACKAGE_RUNNER_TYPE;
     }
 
     @Override
     public String getDisplayName() {
-        return "OctopusDeploy: Push Packages";
+        return "OctopusDeploy: Pack";
     }
 
     @Override
     public String getDescription() {
-        return "Pushes package files (.nupkg, .zip, .tar.gz, etc.) to an Octopus Deploy server";
+        return "Packages files (.nupkg, .zip, .tar.gz, etc.)";
     }
 
     @Nullable
@@ -73,9 +73,11 @@ public class OctopusPushPackageRunType extends RunType {
                 final Collection<InvalidProperty> result = new ArrayList<InvalidProperty>();
                 if (p == null) return result;
 
-                checkNotEmpty(p, c.getApiKey(), "API key must be specified", result);
-                checkNotEmpty(p, c.getServerKey(), "Server must be specified", result);
-                checkNotEmpty(p, c.getPackagePathsKey(), "Package paths must be specified", result);
+                checkNotEmpty(p, c.getPackageIdKey(), "Package ID must be specified", result);
+                checkNotEmpty(p, c.getPackageFormatKey(), "Package format must be specified", result);
+                checkNotEmpty(p, c.getPackageVersionKey(), "Package version be specified", result);
+                checkNotEmpty(p, c.getPackageSourcePathKey(), "Source path must be specified", result);
+                checkNotEmpty(p, c.getPackageOutputPathKey(), "Output path must be specified", result);
 
                 return result;
             }
@@ -85,13 +87,13 @@ public class OctopusPushPackageRunType extends RunType {
     @Nullable
     @Override
     public String getEditRunnerParamsJspFilePath() {
-        return pluginDescriptor.getPluginResourcesPath("editOctopusPushPackage.jsp");
+        return pluginDescriptor.getPluginResourcesPath("editOctopusPackPackage.jsp");
     }
 
     @Nullable
     @Override
     public String getViewRunnerParamsJspFilePath() {
-        return pluginDescriptor.getPluginResourcesPath("viewOctopusPushPackage.jsp");
+        return pluginDescriptor.getPluginResourcesPath("viewOctopusPackPackage.jsp");
     }
 
     @Nullable

--- a/octopus-server/src/main/resources/META-INF/build-server-plugin-Octopus.TeamCity.xml
+++ b/octopus-server/src/main/resources/META-INF/build-server-plugin-Octopus.TeamCity.xml
@@ -10,4 +10,5 @@
     <bean class="octopus.teamcity.server.OctopusDeployReleaseRunType"/>
     <bean class="octopus.teamcity.server.OctopusPromoteReleaseRunType"/>
     <bean class="octopus.teamcity.server.OctopusPushPackageRunType"/>
+    <bean class="octopus.teamcity.server.OctopusPackPackageRunType"/>
 </beans>

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusPackPackage.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusPackPackage.jsp
@@ -1,0 +1,101 @@
+<%@ include file="/include-internal.jsp"%>
+<%@ taglib prefix="props" tagdir="/WEB-INF/tags/props" %>
+<%@ taglib prefix="forms" tagdir="/WEB-INF/tags/forms" %>
+<%@ taglib prefix="l" tagdir="/WEB-INF/tags/layout" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<%--
+  ~ Copyright 2000-2012 Octopus Deploy Pty. Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+
+<jsp:useBean id="keys" class="octopus.teamcity.common.OctopusConstants" />
+<jsp:useBean id="propertiesBean" scope="request" type="jetbrains.buildServer.controllers.BasePropertiesBean"/>
+
+<l:settingsGroup title="Pack">
+
+  <tr>
+    <th>Package ID:<l:star/></th>
+    <td>
+      <props:textProperty name="${keys.packageIdKey}" className="longField" />
+      <span class="error" id="error_${keys.packageIdKey}"></span>
+      <span class="smallNote">
+        The package's identifier.
+      </span>
+    </td>
+  </tr>
+  <tr>
+    <th>Package format:<l:star/></th>
+    <td>
+      <props:selectProperty name="${keys.packageFormatKey}" multiple="false">
+        <props:option value="NuPkg" selected="${keys.packageFormatKey == 'NuPkg'}">NuPkg</props:option>
+        <props:option value="Zip" selected="${keys.packageFormatKey == 'Zip'}">Zip</props:option>
+      </props:selectProperty>
+      <span class="error" id="error_${keys.packageFormatKey}"></span>
+      <span class="smallNote">
+        The package's format, e.g. "NuGet" or "zip". Defaults to NuGet if left blank.
+      </span>
+    </td>
+  </tr>
+  <tr>
+    <th>Package version:<l:star/></th>
+    <td>
+      <props:textProperty name="${keys.packageVersionKey}" className="longField" />
+      <span class="error" id="error_${keys.packageVersionKey}"></span>
+      <span class="smallNote">
+        The package's version, e.g. "NuGet" or "zip". Defaults to NuGet if left blank.
+      </span>
+    </td>
+  </tr>
+    
+  <tr>
+    <th>Source path:<l:star/></th>
+    <td>
+      <props:textProperty name="${keys.packageSourcePathKey}" className="longField" />
+      <span class="error" id="error_${keys.packageSourcePathKey}"></span>
+      <span class="smallNote">
+        Directory to create package from.
+      </span>
+    </td>
+  </tr>
+    
+  <tr>
+    <th>Output path:<l:star/></th>
+    <td>
+      <props:textProperty name="${keys.packageOutputPathKey}" className="longField" />
+      <span class="error" id="error_${keys.packageOutputPathKey}"></span>
+      <span class="smallNote">
+        Directory to write the package to.
+      </span>
+    </td>
+  </tr>
+
+  <tr class="advancedSetting">
+    <th>Publish packages as build artifacts:</th>
+    <td>
+      <props:checkboxProperty name="${keys.publishArtifactsKey}" />
+      <span class="error" id="error_${keys.publishArtifactsKey}"></span>
+      <span class="smallNote">Set this option to automatically publish any packages as TeamCity build artifacts. This is useful if you are creating a package from a directory, and want the package to appear in TeamCity as a build artifact.</span>
+    </td>
+  </tr>
+
+  <tr class="advancedSetting">
+    <th>Additional command line arguments:</th>
+    <td>
+      <props:textProperty name="${keys.commandLineArgumentsKey}" className="longField"/>
+      <span class="error" id="error_${keys.commandLineArgumentsKey}"></span>
+      <span class="smallNote">Additional arguments to be passed to <a href="https://github.com/OctopusDeploy/Octo.exe">Octo.exe</a></span>
+    </td>
+  </tr>
+</l:settingsGroup>

--- a/octopus-server/src/main/resources/buildServerResources/viewOctopusPackPackage.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/viewOctopusPackPackage.jsp
@@ -1,0 +1,54 @@
+<%@ include file="/include-internal.jsp"%>
+<%@ taglib prefix="props" tagdir="/WEB-INF/tags/props" %>
+<%@ taglib prefix="forms" tagdir="/WEB-INF/tags/forms" %>
+<%@ taglib prefix="l" tagdir="/WEB-INF/tags/layout" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<%--
+  ~ Copyright 2000-2012 Octopus Deploy Pty. Ltd.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  --%>
+
+<jsp:useBean id="keys" class="octopus.teamcity.common.OctopusConstants"/>
+<jsp:useBean id="propertiesBean" scope="request" type="jetbrains.buildServer.controllers.BasePropertiesBean"/>
+
+<div class="parameter">
+  Package ID:
+  <strong><props:displayValue name="${keys.packageIdKey}" emptyValue="not specified"/></strong>
+</div>
+
+<div class="parameter">
+  Package format:
+  <strong><props:displayValue name="${keys.packageFormat}" emptyValue="not specified"/></strong>
+</div>
+
+<div class="parameter">
+  Package version:
+  <strong><props:displayValue name="${keys.packageVersion}" emptyValue="not specified"/></strong>
+</div>
+      
+<div class="parameter">
+  Source path:
+  <strong><props:displayValue name="${keys.packageSourcePathKey}" emptyValue="not specified"/></strong>
+</div>
+
+<div class="parameter">
+  Output path:
+  <strong><props:displayValue name="${keys.packageOutputPathKey}" emptyValue="not specified"/></strong>
+</div>
+
+<div class="parameter">
+  Publish packages as build artifacts:
+  <strong><props:displayValue name="${keys.publishArtifactsKey}" emptyValue="not specified"/></strong>
+</div>


### PR DESCRIPTION
Added a step to allow `octo pack` separate to pushing to Octopus. This also allows packing of NuGet packages, whereas the existing push step only supports Zip because it's using internal functionality of TeamCity.

Objective is also better support for the new `dotnet octo` workflows around .NET Core builds, on .NET Core only platforms.

Have locally tested both publishing the artifact to the TeamCity feed and also not doing that and using  the Octopus Push step to push the NuPkg to Octopus.