### PR TITLE
Add null check on VcsRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This plug-in allows TeamCity builds to trigger deployments in Octopus Deploy.
 
 ## Get the plugin
 
-Download the plugin from [the Octopus Deploy downloads page](http://octopusdeploy.com/downloads).
+Download the plugin from [the Octopus Deploy downloads page](http://octopusdeploy.com/downloads) or the [JetBrains plugins downloads](<https://plugins.jetbrains.com/plugin/9038-octopus-deploy>).
 
 Installation and usage instructions are available in [the Octopus Deploy documentation](http://octopusdeploy.com/documentation/integration/teamcity). 
 
@@ -18,7 +18,7 @@ To build the plugin from code:
     directory to the location where you extracted or installed TeamCity locally). 
     The `mvnw` script will download Maven for you if it is not already installed.
  5. The plugin is available at `octopus-distribution/target/Octopus.TeamCity.zip`
- 
+
 ## Editing and debugging in IntelliJ
 
 1. Install TeamCity locally to `C:\TeamCity`. Allow the service to start for the first time, and add an 

--- a/octopus-server/src/main/java/octopus/teamcity/server/OctopusMetadataBuildStartProcessor.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/OctopusMetadataBuildStartProcessor.java
@@ -61,7 +61,9 @@ public class OctopusMetadataBuildStartProcessor implements BuildStartContextProc
 
         buildStartContext.addSharedParameter("commits", jsonData);
         buildStartContext.addSharedParameter("vcstype", vcsType);
-        buildStartContext.addSharedParameter("vcsroot", vcsRootUrl);
+        if (vcsRootUrl != null) {
+            buildStartContext.addSharedParameter("vcsroot", vcsRootUrl);
+        }
     }
 
     public void register() {


### PR DESCRIPTION
The TeamCity code doesn't like nulls in the shared parameters, so omit the parameter rather than try to add a null.

Fixes OctopusDeploy/Issues#5514