### PR TITLE
Pass the server's root Url to the agent

### DIFF
--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusMetadataBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusMetadataBuildProcess.java
@@ -27,14 +27,12 @@ import java.util.Map;
 
 public class OctopusMetadataBuildProcess extends OctopusBuildProcess {
 
-    private final String serverUrl;
     private final File checkoutDir;
     private final Map<String, String> sharedConfigParameters;
 
     public OctopusMetadataBuildProcess(@NotNull AgentRunningBuild runningBuild, @NotNull BuildRunnerContext context) {
         super(runningBuild, context);
 
-        serverUrl = runningBuild.getAgentConfiguration().getServerUrl();
         checkoutDir = runningBuild.getCheckoutDirectory();
         sharedConfigParameters = runningBuild.getSharedConfigParameters();
     }
@@ -67,7 +65,7 @@ public class OctopusMetadataBuildProcess extends OctopusBuildProcess {
                     sharedConfigParameters.get("build.vcs.number"),
                     sharedConfigParameters.get("commits"),
                     commentParser,
-                    serverUrl,
+                    sharedConfigParameters.get("serverRootUrl"),
                     Long.toString(build.getBuildId()),
                     build.getBuildNumber());
 

--- a/octopus-server/src/main/java/octopus/teamcity/server/OctopusMetadataBuildStartProcessor.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/OctopusMetadataBuildStartProcessor.java
@@ -3,9 +3,7 @@ package octopus.teamcity.server;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import jetbrains.buildServer.ExtensionHolder;
-import jetbrains.buildServer.serverSide.BuildStartContext;
-import jetbrains.buildServer.serverSide.BuildStartContextProcessor;
-import jetbrains.buildServer.serverSide.SRunningBuild;
+import jetbrains.buildServer.serverSide.*;
 import jetbrains.buildServer.vcs.SVcsModification;
 import jetbrains.buildServer.vcs.SelectPrevBuildPolicy;
 import jetbrains.buildServer.vcs.VcsRootInstanceEntry;
@@ -19,9 +17,12 @@ import java.util.Map;
 public class OctopusMetadataBuildStartProcessor implements BuildStartContextProcessor {
 
     private ExtensionHolder extensionHolder;
+    private WebLinks webLinks;
 
-    public OctopusMetadataBuildStartProcessor(@NotNull ExtensionHolder extensionHolder) {
+    public OctopusMetadataBuildStartProcessor(@NotNull final ExtensionHolder extensionHolder,
+                                              @NotNull final WebLinks webLinks) {
         this.extensionHolder = extensionHolder;
+        this.webLinks = webLinks;
     }
 
     @Override
@@ -59,6 +60,7 @@ public class OctopusMetadataBuildStartProcessor implements BuildStartContextProc
                 .create();
         final String jsonData = gson.toJson(commits);
 
+        buildStartContext.addSharedParameter("serverRootUrl", webLinks.getRootUrl());
         buildStartContext.addSharedParameter("commits", jsonData);
         buildStartContext.addSharedParameter("vcstype", vcsType);
         if (vcsRootUrl != null) {


### PR DESCRIPTION
This PR addresses issues when the agent uses a different Url to access the server than the UI does. The value shown in the server's administration page is the value we meant to get, but it isn't what's available in the API we originally called, that is the Url the agent uses to talk to the server.

Fixes OctopusDeploy/Issues#5635