### PR TITLE
Include the Deployment Timeout and Cancel On Timeout options

### DIFF
--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusCreateReleaseBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusCreateReleaseBuildProcess.java
@@ -54,6 +54,9 @@ public class OctopusCreateReleaseBuildProcess extends OctopusBuildProcess {
                 final String tenants = parameters.get(constants.getTenantsKey());
                 final String tenanttags = parameters.get(constants.getTenantTagsKey());
                 final boolean wait = Boolean.parseBoolean(parameters.get(constants.getWaitForDeployments()));
+                final String deploymentTimeout = parameters.get(constants.getDeploymentTimeout());
+                final boolean cancelOnTimeout = Boolean.parseBoolean(parameters.get(constants.getCancelDeploymentOnTimeout()));
+
 
                 commands.add("create-release");
                 commands.add("--server");
@@ -87,6 +90,15 @@ public class OctopusCreateReleaseBuildProcess extends OctopusBuildProcess {
 
                 if (wait && deployTo != null && !deployTo.isEmpty()) {
                     commands.add("--progress");
+
+                    if (!deploymentTimeout.isEmpty()) {
+                        commands.add("--deploymenttimeout");
+                        commands.add(deploymentTimeout);
+                    }
+
+                    if (cancelOnTimeout) {
+                        commands.add("--cancelontimeout");
+                    }
                 }
 
                 for(String tenant : splitCommaSeparatedValues(tenants)) {

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusDeployReleaseBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusDeployReleaseBuildProcess.java
@@ -53,6 +53,8 @@ public class OctopusDeployReleaseBuildProcess extends OctopusBuildProcess {
                 final String tenanttags = parameters.get(constants.getTenantTagsKey());
                 final String projectName = parameters.get(constants.getProjectNameKey());
                 final boolean wait = Boolean.parseBoolean(parameters.get(constants.getWaitForDeployments()));
+                final String deploymentTimeout = parameters.get(constants.getDeploymentTimeout());
+                final boolean cancelOnTimeout = Boolean.parseBoolean(parameters.get(constants.getCancelDeploymentOnTimeout()));
 
                 commands.add("deploy-release");
                 commands.add("--server");
@@ -93,6 +95,15 @@ public class OctopusDeployReleaseBuildProcess extends OctopusBuildProcess {
 
                 if (wait && deployTo != null && !deployTo.isEmpty()) {
                     commands.add("--progress");
+
+                    if (!deploymentTimeout.isEmpty()) {
+                        commands.add("--deploymenttimeout");
+                        commands.add(deploymentTimeout);
+                    }
+
+                    if (cancelOnTimeout) {
+                        commands.add("--cancelontimeout");
+                    }
                 }
 
                 if (commandLineArguments != null && !commandLineArguments.isEmpty()) {

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusPromoteReleaseBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusPromoteReleaseBuildProcess.java
@@ -53,6 +53,8 @@ public class OctopusPromoteReleaseBuildProcess extends OctopusBuildProcess {
                 final String tenants = parameters.get(constants.getTenantsKey());
                 final String tenanttags = parameters.get(constants.getTenantTagsKey());
                 final boolean wait = Boolean.parseBoolean(parameters.get(constants.getWaitForDeployments()));
+                final String deploymentTimeout = parameters.get(constants.getDeploymentTimeout());
+                final boolean cancelOnTimeout = Boolean.parseBoolean(parameters.get(constants.getCancelDeploymentOnTimeout()));
 
                 commands.add("promote-release");
                 commands.add("--server");
@@ -80,6 +82,15 @@ public class OctopusPromoteReleaseBuildProcess extends OctopusBuildProcess {
 
                 if (wait && deployTo != null && !deployTo.isEmpty()) {
                     commands.add("--progress");
+
+                    if (!deploymentTimeout.isEmpty()) {
+                        commands.add("--deploymenttimeout");
+                        commands.add(deploymentTimeout);
+                    }
+
+                    if (cancelOnTimeout) {
+                        commands.add("--cancelontimeout");
+                    }
                 }
 
                 for(String tenant : splitCommaSeparatedValues(tenants)) {

--- a/octopus-common/src/main/java/octopus/teamcity/common/OctopusConstants.java
+++ b/octopus-common/src/main/java/octopus/teamcity/common/OctopusConstants.java
@@ -113,12 +113,9 @@ public class OctopusConstants {
 		return "octopus_channel_name";
 	}
 
-    public String getWaitForDeployments() {
-        return "octopus_waitfordeployments";
-    }
-    public String getShowProgress() {
-        return "octopus_progress";
-    }
+    public String getWaitForDeployments() { return "octopus_waitfordeployments"; }
+    public String getDeploymentTimeout() { return "octopus_deploymenttimeout"; }
+    public String getCancelDeploymentOnTimeout() { return "octopus_cancelontimeout"; }
 
     public String getVerboseLoggingKey() {
         return "octopus_verbose_logging";

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusCreateRelease.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusCreateRelease.jsp
@@ -120,8 +120,23 @@
     <span class="smallNote">If checked, the build process will only succeed if the deployment is successful. Output from the deployment will appear in the build output.</span>
   </td>
 </tr>
+<tr>
+  <th>Time to wait for deployment:</th>
+  <td>
+    <props:textProperty name="${keys.deploymentTimeout}" />
+    <span class="error" id="error_${keys.deploymentTimeout}"></span>
+    <span class="smallNote">The amount of time, specified in timespan format, to wait for the deployment to complete. Default is 00:10:00 if left blank. The deployment task itself does not timeout, this timeout is  purely how long the client will keep polling to see if it has completed.</span>
+  </td>
+</tr>
+<tr>
+  <th>Cancel deployment on timeout:</th>
+  <td>
+    <props:checkboxProperty name="${keys.cancelDeploymentOnTimeout}" />
+    <span class="error" id="error_${keys.cancelDeploymentOnTimeout}"></span>
+    <span class="smallNote">If checked, and <strong>Show deployment progress</strong> is also checked, then the deployment will be explicitly canceled if the time to wait has expired and the task has not completed.</span>
+  </td>
+</tr>
 </l:settingsGroup>
-
 
 <l:settingsGroup title="Advanced">
 <tr>

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusDeployRelease.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusDeployRelease.jsp
@@ -105,6 +105,22 @@
             <span class="smallNote">If checked, the build process will only succeed if the deployment is successful.</span>
         </td>
     </tr>
+    <tr>
+        <th>Time to wait for deployment:</th>
+        <td>
+            <props:textProperty name="${keys.deploymentTimeout}" />
+            <span class="error" id="error_${keys.deploymentTimeout}"></span>
+            <span class="smallNote">The amount of time, specified in timespan format, to wait for the deployment to complete. Default is 00:10:00 if left blank. The deployment task itself does not timeout, this timeout is  purely how long the client will keep polling to see if it has completed.</span>
+        </td>
+    </tr>
+    <tr>
+        <th>Cancel deployment on timeout:</th>
+        <td>
+            <props:checkboxProperty name="${keys.cancelDeploymentOnTimeout}" />
+            <span class="error" id="error_${keys.cancelDeploymentOnTimeout}"></span>
+            <span class="smallNote">If checked, and <strong>Show deployment progress</strong> is also checked, then the deployment will be explicitly canceled if the time to wait has expired and the task has not completed.</span>
+        </td>
+    </tr>
 </l:settingsGroup>
 
 

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusPromoteRelease.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusPromoteRelease.jsp
@@ -125,6 +125,22 @@
     <span class="smallNote">If checked, the build process will only succeed if the deployment is successful.</span>
   </td>
 </tr>
+<tr>
+    <th>Time to wait for deployment:</th>
+    <td>
+        <props:textProperty name="${keys.deploymentTimeout}" />
+        <span class="error" id="error_${keys.deploymentTimeout}"></span>
+        <span class="smallNote">The amount of time, specified in timespan format, to wait for the deployment to complete. Default is 00:10:00 if left blank. The deployment task itself does not timeout, this timeout is  purely how long the client will keep polling to see if it has completed.</span>
+    </td>
+</tr>
+<tr>
+    <th>Cancel deployment on timeout:</th>
+    <td>
+        <props:checkboxProperty name="${keys.cancelDeploymentOnTimeout}" />
+        <span class="error" id="error_${keys.cancelDeploymentOnTimeout}"></span>
+        <span class="smallNote">If checked, and <strong>Show deployment progress</strong> is also checked, then the deployment will be explicitly canceled if the time to wait has expired and the task has not completed.</span>
+    </td>
+</tr>
 </l:settingsGroup>
 
 

--- a/octopus-server/src/main/resources/buildServerResources/viewOctopusCreateRelease.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/viewOctopusCreateRelease.jsp
@@ -38,6 +38,16 @@
 </div>
 
 <div class="parameter">
-    Show progress:
+    Show deployment progress:
     <strong><props:displayValue name="${keys.waitForDeployments}" emptyValue="not specified"/></strong>
+</div>
+
+<div class="parameter">
+    Time to wait for deployment:
+    <strong><props:displayValue name="${keys.deploymentTimeout}" emptyValue="not specified"/></strong>
+</div>
+
+<div class="parameter">
+    Cancel deployment on timeout:
+    <strong><props:displayValue name="${keys.cancelDeploymentOnTimeout}" emptyValue="not specified"/></strong>
 </div>

--- a/octopus-server/src/main/resources/buildServerResources/viewOctopusDeployRelease.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/viewOctopusDeployRelease.jsp
@@ -33,6 +33,16 @@
 </div>
 
 <div class="parameter">
-    Show progress:
+    Show deployment progress:
     <strong><props:displayValue name="${keys.waitForDeployments}" emptyValue="not specified"/></strong>
+</div>
+
+<div class="parameter">
+    Time to wait for deployment:
+    <strong><props:displayValue name="${keys.deploymentTimeout}" emptyValue="not specified"/></strong>
+</div>
+
+<div class="parameter">
+    Cancel deployment on timeout:
+    <strong><props:displayValue name="${keys.cancelDeploymentOnTimeout}" emptyValue="not specified"/></strong>
 </div>

--- a/octopus-server/src/main/resources/buildServerResources/viewOctopusPromoteRelease.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/viewOctopusPromoteRelease.jsp
@@ -49,6 +49,16 @@
 </div>
 
 <div class="parameter">
-    Show progress:
+    Show deployment progress:
     <strong><props:displayValue name="${keys.waitForDeployments}" emptyValue="not specified"/></strong>
+</div>
+
+<div class="parameter">
+    Time to wait for deployment:
+    <strong><props:displayValue name="${keys.deploymentTimeout}" emptyValue="not specified"/></strong>
+</div>
+
+<div class="parameter">
+    Cancel deployment on timeout:
+    <strong><props:displayValue name="${keys.cancelDeploymentOnTimeout}" emptyValue="not specified"/></strong>
 </div>


### PR DESCRIPTION
Add these as options to make it easy for users to discover and use these settings. No specific validation has been included, the options only get used when they are relevant, and not seeing a need to be forceful in not have them set or anything like that when they aren't relevant.

Relates to OctopusDeploy/Issues#5388