### PR TITLE
Include the gson file in the packages for server and agent

### DIFF
--- a/octopus-agent/assembly.xml
+++ b/octopus-agent/assembly.xml
@@ -18,5 +18,11 @@
             <outputDirectory>/lib</outputDirectory>
             <outputFileNameMapping>Octopus.TeamCity-${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
         </dependencySet>
+        <dependencySet>
+            <includes>
+                <include>com.google.code.gson:gson</include>
+            </includes>
+            <outputDirectory>/lib</outputDirectory>
+        </dependencySet>
     </dependencySets>
 </assembly>

--- a/octopus-distribution/assembly.xml
+++ b/octopus-distribution/assembly.xml
@@ -29,5 +29,11 @@
             <outputDirectory>server</outputDirectory>
             <outputFileNameMapping>Octopus.TeamCity.${artifact.extension}</outputFileNameMapping>
         </dependencySet>
+        <dependencySet>
+            <includes>
+                <include>com.google.code.gson:gson</include>
+            </includes>
+            <outputDirectory>server</outputDirectory>
+        </dependencySet>
     </dependencySets>
 </assembly>


### PR DESCRIPTION
This PR includes the gson jar file in the distribution for the TeamCity server and agent packages.

Fixes #21 