### PR TITLE
Fix NPE from #25 in another location.

### DIFF
--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusDeployReleaseBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusDeployReleaseBuildProcess.java
@@ -96,7 +96,7 @@ public class OctopusDeployReleaseBuildProcess extends OctopusBuildProcess {
                 if (wait && deployTo != null && !deployTo.isEmpty()) {
                     commands.add("--progress");
 
-                    if (!deploymentTimeout.isEmpty()) {
+                    if (deploymentTimeout != null && !deploymentTimeout.isEmpty()) {
                         commands.add("--deploymenttimeout");
                         commands.add(deploymentTimeout);
                     }

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusPromoteReleaseBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusPromoteReleaseBuildProcess.java
@@ -83,7 +83,7 @@ public class OctopusPromoteReleaseBuildProcess extends OctopusBuildProcess {
                 if (wait && deployTo != null && !deployTo.isEmpty()) {
                     commands.add("--progress");
 
-                    if (!deploymentTimeout.isEmpty()) {
+                    if (deploymentTimeout != null && !deploymentTimeout.isEmpty()) {
                         commands.add("--deploymenttimeout");
                         commands.add(deploymentTimeout);
                     }


### PR DESCRIPTION
Fixes the NPE described in issue #25, but two other locations not touched by PR #27.

```
java.lang.NullPointerException
	at octopus.teamcity.agent.OctopusDeployReleaseBuildProcess$1.buildCommand(OctopusDeployReleaseBuildProcess.java:99)
	at octopus.teamcity.agent.OctopusCommandBuilder.buildMaskedCommand(OctopusCommandBuilder.java:32)
	at octopus.teamcity.agent.OctopusBuildProcess.startOcto(OctopusBuildProcess.java:87)
	at octopus.teamcity.agent.OctopusBuildProcess.start(OctopusBuildProcess.java:54)
	at jetbrains.buildServer.agent.impl.buildStages.runnerStages.start.CallRunnerStage.doBuildStage(CallRunnerStage.java:61)
	at jetbrains.buildServer.agent.impl.buildStages.RunnerStagesExecutor$1.callStage(RunnerStagesExecutor.java:25)
	at jetbrains.buildServer.agent.impl.buildStages.RunnerStagesExecutor$1.callStage(RunnerStagesExecutor.java:18)
	at jetbrains.buildServer.agent.impl.buildStages.StagesExecutor.callRunStage(StagesExecutor.java:78)
	at jetbrains.buildServer.agent.impl.buildStages.StagesExecutor.doStages(StagesExecutor.java:37)
	at jetbrains.buildServer.agent.impl.buildStages.RunnerStagesExecutor.doStages(RunnerStagesExecutor.java:18)
	at jetbrains.buildServer.agent.impl.buildStages.startStages.steps.RunnerContextExecutor.callRunnerStages(RunnerContextExecutor.java:43)
	at jetbrains.buildServer.agent.impl.buildStages.startStages.steps.StepExecutor.processNextStep(StepExecutor.java:25)
	at jetbrains.buildServer.agent.impl.buildStages.startStages.steps.ForEachBuildRunnerStage.executeRunnerStep(ForEachBuildRunnerStage.java:138)
	at jetbrains.buildServer.agent.impl.buildStages.startStages.steps.ForEachBuildRunnerStage.runStep(ForEachBuildRunnerStage.java:123)
	at jetbrains.buildServer.agent.impl.buildStages.startStages.steps.ForEachBuildRunnerStage.executeBuildRunners(ForEachBuildRunnerStage.java:83)
	at jetbrains.buildServer.agent.impl.buildStages.startStages.steps.ForEachBuildRunnerStage.doBuildStage(ForEachBuildRunnerStage.java:44)
	at jetbrains.buildServer.agent.impl.buildStages.BuildStagesExecutor$1.callStage(BuildStagesExecutor.java:31)
	at jetbrains.buildServer.agent.impl.buildStages.BuildStagesExecutor$1.callStage(BuildStagesExecutor.java:24)
	at jetbrains.buildServer.agent.impl.buildStages.StagesExecutor.callRunStage(StagesExecutor.java:78)
	at jetbrains.buildServer.agent.impl.buildStages.StagesExecutor.doStages(StagesExecutor.java:37)
	at jetbrains.buildServer.agent.impl.buildStages.BuildStagesExecutor.doStages(BuildStagesExecutor.java:24)
	at jetbrains.buildServer.agent.impl.BuildRunActionImpl.doStages(BuildRunActionImpl.java:79)
	at jetbrains.buildServer.agent.impl.BuildRunActionImpl.runBuild(BuildRunActionImpl.java:55)
	at jetbrains.buildServer.agent.impl.BuildAgentImpl.doActualBuild(BuildAgentImpl.java:312)
	at jetbrains.buildServer.agent.impl.BuildAgentImpl.access$100(BuildAgentImpl.java:55)
	at jetbrains.buildServer.agent.impl.BuildAgentImpl$1.run(BuildAgentImpl.java:275)
	at java.lang.Thread.run(Thread.java:745)
```