### PR TITLE
Add additional cli arguments to build information

### DIFF
--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
@@ -90,6 +90,7 @@ public class OctopusBuildInformationBuildProcess extends OctopusBuildProcess {
                 final String spaceName = parameters.get(constants.getSpaceName());
                 final String packageIds = parameters.get(constants.getPackageIdKey());
                 final String packageVersion = parameters.get(constants.getPackageVersionKey());
+                final String commandLineArguments = parameters.get(constants.getCommandLineArgumentsKey());
 
                 final String forcePush = parameters.get(constants.getForcePushKey());
                 OverwriteMode overwriteMode = OverwriteMode.FailIfExists;
@@ -130,6 +131,10 @@ public class OctopusBuildInformationBuildProcess extends OctopusBuildProcess {
                 if (overwriteMode != OverwriteMode.FailIfExists) {
                     commands.add("--overwrite-mode");
                     commands.add(overwriteMode.name());
+                }
+
+                if (commandLineArguments != null && !commandLineArguments.isEmpty()) {
+                    commands.addAll(splitSpaceSeparatedValues(commandLineArguments));
                 }
 
                 return commands.toArray(new String[commands.size()]);

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusBuildInformation.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusBuildInformation.jsp
@@ -93,5 +93,15 @@
       <span class="smallNote">Set this to get more verbose logging.</span>
     </td>
   </tr>
+</l:settingsGroup>
 
+<l:settingsGroup title="Advanced">
+  <tr>
+    <th>Additional command line arguments:</th>
+    <td>
+      <props:textProperty name="${keys.commandLineArgumentsKey}" className="longField"/>
+      <span class="error" id="error_${keys.commandLineArgumentsKey}"></span>
+      <span class="smallNote">Additional arguments to be passed to <a href="https://g.octopushq.com/OctoExePush">Octopus CLI</a></span>
+    </td>
+  </tr>
 </l:settingsGroup>

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusCreateRelease.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusCreateRelease.jsp
@@ -171,12 +171,12 @@
 </l:settingsGroup>
 
 <l:settingsGroup title="Advanced">
-<tr>
-  <th>Additional command line arguments:</th>
-  <td>
-    <props:textProperty name="${keys.commandLineArgumentsKey}" className="longField"/>
-    <span class="error" id="error_${keys.commandLineArgumentsKey}"></span>
-    <span class="smallNote">Additional arguments to be passed to <a href="https://g.octopushq.com/OctoExeCreateRelease">Octopus CLI</a></span>
-  </td>
-</tr>
+  <tr>
+    <th>Additional command line arguments:</th>
+    <td>
+      <props:textProperty name="${keys.commandLineArgumentsKey}" className="longField"/>
+      <span class="error" id="error_${keys.commandLineArgumentsKey}"></span>
+      <span class="smallNote">Additional arguments to be passed to <a href="https://g.octopushq.com/OctoExeCreateRelease">Octopus CLI</a></span>
+    </td>
+  </tr>
 </l:settingsGroup>

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusPackPackage.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusPackPackage.jsp
@@ -89,8 +89,10 @@
       <span class="smallNote">Set this option to automatically publish any packages as TeamCity build artifacts. This is useful if you are creating a package from a directory, and want the package to appear in TeamCity as a build artifact.</span>
     </td>
   </tr>
+</l:settingsGroup>
 
-  <tr class="advancedSetting">
+<l:settingsGroup title="Advanced">
+  <tr>
     <th>Additional command line arguments:</th>
     <td>
       <props:textProperty name="${keys.commandLineArgumentsKey}" className="longField"/>

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusPushPackage.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusPushPackage.jsp
@@ -83,8 +83,10 @@
       <span class="smallNote">Set this option to automatically publish any packages as TeamCity build artifacts. This is useful if you are creating a package from a directory, and want the package to appear in TeamCity as a build artifact.</span>
     </td>
   </tr>
+</l:settingsGroup>
 
-  <tr class="advancedSetting">
+<l:settingsGroup title="Advanced">
+  <tr>
     <th>Additional command line arguments:</th>
     <td>
       <props:textProperty name="${keys.commandLineArgumentsKey}" className="longField"/>


### PR DESCRIPTION
The build information plugin option does not currently allow for passing command line arguments. This PR adds a block of jsp `editBuildInformation` to allow passing additional command line args and updates the `BuildInformationBuildProcess` to add these arguments to the collected commands.

Additionally, this PR also makes each plugin option consistent with respect to the `Additional command line arguments:` under the 'Advanced' settings group.

Example result from this change:
(Note the --proxy argument now appears in the cli call)
![image](https://user-images.githubusercontent.com/30226456/105274326-12778200-5bf1-11eb-8878-a5bf4a3d2de5.png)
