### PR TITLE
Update to latest version of teamcity-rest-client

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -14,7 +14,7 @@ dependencyManagement {
       entry 'common-api'
       entry 'server-api'
     }
-    dependency 'org.jetbrains.teamcity:teamcity-rest-client:3.5'
+    dependency 'org.jetbrains.teamcity:teamcity-rest-client:1.14.0'
 
     dependency 'com.google.guava:guava:30.1.1-jre'
 

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
@@ -71,7 +71,8 @@ public class OctopusBuildInformationBuildProcess extends OctopusBuildProcess {
             final OctopusBuildInformationBuilder builder = new OctopusBuildInformationBuilder();
 
             final String buildIdString = Long.toString(build.getBuildId());
-            final TeamCityInstance teamCityServer = TeamCityInstance.httpAuth(teamCityServerUrl, build.getAccessUser(), build.getAccessCode());
+            final TeamCityInstance teamCityServer = TeamCityInstanceFactory.httpAuth(teamCityServerUrl, build.getAccessUser(),
+                build.getAccessCode());
             final Build restfulBuild = teamCityServer.build(new BuildId(buildIdString));
 
             final OctopusBuildInformation buildInformation = builder.build(


### PR DESCRIPTION
It appears the teamcity-rest-client versioning got reset in ~2017, and the version currently used is the highest number, but is actually quite old.
It has been updated to be 1.14.0.
This upgrade brings in many up-issues to its dependencies which _may_ resolve some outstanding issues around TLSV2.