### PR TITLE
Force BuildInfo AcceptanceTest to timeout

### DIFF
--- a/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
@@ -112,41 +112,47 @@ public class BuildInformationEndToEndTest {
     } finally {
       // Turns out, some files get written to this directory by TC (as the tcuser) - and they need
       // to be destroyed.
-      teamCityContainers
-          .getServerContainer()
-          .execInContainer("rm", "-rf", "/data/teamcity_server/datadir/system/buildserver.tmp");
-      teamCityContainers
-          .getServerContainer()
-          .execInContainer("rm", "-rf", "/data/teamcity_server/datadir/system/artifacts");
-      teamCityContainers
-          .getServerContainer()
-          .execInContainer(
-              "rm", "-rf", "/data/teamcity_server/datadir/system/caches/plugins.unpacked");
-      teamCityContainers
-          .getServerContainer()
-          .execInContainer(
-              "rm", "-rf", "/data/teamcity_server/datadir/system/caches/pluginsDslCache/src");
-      teamCityContainers
-          .getServerContainer()
-          .execInContainer(
-              "rm",
-              "-rf",
-              "/data/teamcity_server/datadir/system/caches/buildsMetadata/metadataDB.tmp");
+      cleanupContainers(teamCityContainers);
     }
   }
 
   private void waitForBuildToFinish(final Build build, final TeamCityInstance tcRestApi)
       throws InterruptedException {
-    final Duration buildTimeout = Duration.ofSeconds(30);
+    final Duration buildTimeout = Duration.ofSeconds(60);
     final Instant buildStart = Instant.now();
     LOG.info("Waiting for requested build {} to complete", build.getId());
     while (Duration.between(buildStart, Instant.now()).minus(buildTimeout).isNegative()) {
       final Build updatedBuild = tcRestApi.build(build.getId());
       if (updatedBuild.getState().equals(BuildState.FINISHED)) {
+        LOG.info("Build {} completed", build.getId());
         return;
       }
       Thread.sleep(1000);
     }
+    LOG.warn("Build {} failed to complete within expected time limit", build.getId());
     throw new RuntimeException("Build Failed to complete within 30 seconds");
+  }
+
+  private void cleanupContainers(final TeamCityContainers teamCityContainers) throws IOException, InterruptedException {
+    teamCityContainers
+        .getServerContainer()
+        .execInContainer("rm", "-rf", "/data/teamcity_server/datadir/system/buildserver.tmp");
+    teamCityContainers
+        .getServerContainer()
+        .execInContainer("rm", "-rf", "/data/teamcity_server/datadir/system/artifacts");
+    teamCityContainers
+        .getServerContainer()
+        .execInContainer(
+            "rm", "-rf", "/data/teamcity_server/datadir/system/caches/plugins.unpacked");
+    teamCityContainers
+        .getServerContainer()
+        .execInContainer(
+            "rm", "-rf", "/data/teamcity_server/datadir/system/caches/pluginsDslCache/src");
+    teamCityContainers
+        .getServerContainer()
+        .execInContainer(
+            "rm",
+            "-rf",
+            "/data/teamcity_server/datadir/system/caches/buildsMetadata/metadataDB.tmp");
   }
 }

--- a/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
@@ -133,7 +133,8 @@ public class BuildInformationEndToEndTest {
     throw new RuntimeException("Build Failed to complete within 30 seconds");
   }
 
-  private void cleanupContainers(final TeamCityContainers teamCityContainers) throws IOException, InterruptedException {
+  private void cleanupContainers(final TeamCityContainers teamCityContainers)
+      throws IOException, InterruptedException {
     teamCityContainers
         .getServerContainer()
         .execInContainer("rm", "-rf", "/data/teamcity_server/datadir/system/buildserver.tmp");

--- a/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
@@ -109,6 +109,9 @@ public class BuildInformationEndToEndTest {
 
       assertThat(items.size()).isEqualTo(1);
       assertThat(items.get(0).getPackageId()).isEqualTo("mypackage.noreally");
+    } catch (final Exception e) {
+      LOG.info("Failed to execute build");
+      LOG.info(teamCityContainers.getAgentContainer().getLogs());
     } finally {
       // Turns out, some files get written to this directory by TC (as the tcuser) - and they need
       // to be destroyed.

--- a/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
@@ -112,6 +112,7 @@ public class BuildInformationEndToEndTest {
     } catch (final Exception e) {
       LOG.info("Failed to execute build");
       LOG.info(teamCityContainers.getAgentContainer().getLogs());
+      throw e;
     } finally {
       // Turns out, some files get written to this directory by TC (as the tcuser) - and they need
       // to be destroyed.

--- a/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
@@ -140,7 +140,7 @@ public class BuildInformationEndToEndTest {
     final Duration buildTimeout = Duration.ofSeconds(30);
     final Instant buildStart = Instant.now();
     LOG.info("Waiting for requested build {} to complete", build.getId());
-    while (Duration.between(Instant.now(), buildStart).minus(buildTimeout).isNegative()) {
+    while (Duration.between(buildStart, Instant.now()).minus(buildTimeout).isNegative()) {
       final Build updatedBuild = tcRestApi.build(build.getId());
       if (updatedBuild.getState().equals(BuildState.FINISHED)) {
         return;


### PR DESCRIPTION
The time check used to determine if a build had finished within a a given time limit had logic inverted, such that the test would run forever.

This changeset resolves the issue by switching start/end times on the duration calculation.