### PR TITLE
Allow the Step Vnext to be feature flagged

### DIFF
--- a/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
@@ -101,7 +101,9 @@ public class TeamCityFactory {
             .withNetwork(dockerNetwork)
             .withNetworkAliases("server")
             .withEnv(
-                "TEAMCITY_SERVER_OPTS", "-Droot.log.level=TRACE -Dteamcity.development.mode=true")
+                "TEAMCITY_SERVER_OPTS",
+                "-Droot.log.level=TRACE -Dteamcity.development.mode=true " +
+                    "-Doctopus.enable.step.vnext=true")
             .withStartupTimeout(Duration.ofMinutes(2))
             .withFileSystemBind(
                 teamCityDataDir.toAbsolutePath().toString(),

--- a/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
@@ -102,8 +102,8 @@ public class TeamCityFactory {
             .withNetworkAliases("server")
             .withEnv(
                 "TEAMCITY_SERVER_OPTS",
-                "-Droot.log.level=TRACE -Dteamcity.development.mode=true " +
-                    "-Doctopus.enable.step.vnext=true")
+                "-Droot.log.level=TRACE -Dteamcity.development.mode=true "
+                    + "-Doctopus.enable.step.vnext=true")
             .withStartupTimeout(Duration.ofMinutes(2))
             .withFileSystemBind(
                 teamCityDataDir.toAbsolutePath().toString(),

--- a/octopus-server/src/main/java/octopus/teamcity/server/OctopusGenericRunType.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/OctopusGenericRunType.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import com.intellij.openapi.util.text.StringUtil;
 import jetbrains.buildServer.serverSide.PropertiesProcessor;
 import jetbrains.buildServer.serverSide.RunType;
 import jetbrains.buildServer.serverSide.RunTypeRegistry;
@@ -19,9 +20,13 @@ public class OctopusGenericRunType extends RunType {
   private final PluginDescriptor pluginDescriptor;
 
   public OctopusGenericRunType(
-      final RunTypeRegistry runTypeRegistry, final PluginDescriptor pluginDescriptor) {
+      final String enableStepVnext,
+      final RunTypeRegistry runTypeRegistry,
+      final PluginDescriptor pluginDescriptor) {
     this.pluginDescriptor = pluginDescriptor;
-    runTypeRegistry.registerRunType(this);
+    if (!StringUtil.isEmpty(enableStepVnext) && Boolean.parseBoolean(enableStepVnext)) {
+      runTypeRegistry.registerRunType(this);
+    }
   }
 
   @Override

--- a/octopus-server/src/main/resources/META-INF/build-server-plugin-Octopus.TeamCity.xml
+++ b/octopus-server/src/main/resources/META-INF/build-server-plugin-Octopus.TeamCity.xml
@@ -13,5 +13,7 @@
     <bean class="octopus.teamcity.server.OctopusPromoteReleaseRunType"/>
     <bean class="octopus.teamcity.server.OctopusPushPackageRunType"/>
     <bean class="octopus.teamcity.server.OctopusPackPackageRunType"/>
-    <bean class="octopus.teamcity.server.OctopusGenericRunType"/>
+    <bean class="octopus.teamcity.server.OctopusGenericRunType">
+        <constructor-arg value="#{ systemProperties['octopus.enable.step.vnext'] }"/>
+    </bean>
 </beans>

--- a/octopus-server/src/main/resources/buildServerResources/viewOctopusPackPackage.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/viewOctopusPackPackage.jsp
@@ -30,12 +30,12 @@
 
 <div class="parameter">
   Package format:
-  <strong><props:displayValue name="${keys.packageFormatKey}" emptyValue="not specified"/></strong>
+  <strong><props:displayValue name="${keys.packageFormat}" emptyValue="not specified"/></strong>
 </div>
 
 <div class="parameter">
   Package version:
-  <strong><props:displayValue name="${keys.packageVersionKey}" emptyValue="not specified"/></strong>
+  <strong><props:displayValue name="${keys.packageVersion}" emptyValue="not specified"/></strong>
 </div>
       
 <div class="parameter">

--- a/octopus-server/src/main/resources/buildServerResources/viewOctopusPackPackage.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/viewOctopusPackPackage.jsp
@@ -30,12 +30,12 @@
 
 <div class="parameter">
   Package format:
-  <strong><props:displayValue name="${keys.packageFormat}" emptyValue="not specified"/></strong>
+  <strong><props:displayValue name="${keys.packageFormatKey}" emptyValue="not specified"/></strong>
 </div>
 
 <div class="parameter">
   Package version:
-  <strong><props:displayValue name="${keys.packageVersion}" emptyValue="not specified"/></strong>
+  <strong><props:displayValue name="${keys.packageVersionKey}" emptyValue="not specified"/></strong>
 </div>
       
 <div class="parameter">


### PR DESCRIPTION
The OctopusGenericStep has been feature-flagged, such that it will not
appear in a TeamCity instance unless the octopus.enable.step.vnext
system property contains the literal text 'true' in the Teamcity
Server.

This can be done by appending "-Doctopus.enable.step.vnext=true" to the
TEAMCITY_SERVER_OPTS environment variable prior to starting the Teamcity
Server.
