### PR TITLE
Update version in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=6.1.3-SNAPSHOT
+version=6.1.5-SNAPSHOT


### PR DESCRIPTION
The version number in gradle.properties is behind the released version (6.1.5), and should be 6.1.6-SNAPSHOT