### PR TITLE
Github action to create release in OctopusDeploy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         echo "::set-output name=version::$version"
 
     - name: Push a package to Octopus Deploy 🐙
-      uses: OctopusDeploy/push-package-action@<version>
+      uses: OctopusDeploy/push-package-action@v1.0.2
       with:
         overwrite_mode: IgnoreExists
         api_key: ${{ secrets.OCTOPUS_APIKEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Build, Test, Package and Push
+
+# Controls when the action will run.
+on:
+  release:
+    types: [created]
+
+  workflow_dispatch:
+    inputs:
+      release-url:
+        description: "The URL of the github release being created in OD"
+        required: true
+
+jobs:
+  build:
+    name: "Build and Package"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Build with gradle
+        run: ./gradlew build test
+
+      - name: Create Plugin Zip Deployment
+        id: create-package
+        run: |
+        ./gradlew distZip
+        echo "::set-output name=package-created::./gradlew -q packageName"
+        version=`./gradlew properties | grep ^version | awk '{print $2;}'`
+        echo "::set-output name=version::$version"
+
+    - name: Push a package to Octopus Deploy 🐙
+      uses: OctopusDeploy/push-package-action@<version>
+      with:
+        overwrite_mode: IgnoreExists
+        api_key: ${{ secrets.OCTOPUS_APIKEY }}
+        packages: ${{ step.create-package.package-created }}
+        server: ${{ secrets.OCTOPUS_SERVER }}
+
+    - name: Fetch Release Notes
+      id: fetch-release-nodes
+      run: |
+        if ["${{github.event_name}}" = "release"]; then
+           release_notes=curl ${{ github.event_path }} | jq '.body'
+           echo "::set-output name=release_notes::$release_notes"
+        else
+           release_notes=curl ${{ inputs.release-url }} | jq '.body'
+           echo "::set-output name=release_notes::$release_notes"
+        fi
+
+    - name: Create a release in Octopus Deploy 🐙
+      uses: OctopusDeploy/create-release-action@v1.0.2
+      with:
+        api_key: ${{ secrets.OCTOPUS_APIKEY }}
+        server: ${{ secrets.OCTOPUS_SERVER }}
+        space: "Spaces-62"
+        project: "teamcity-plugin"
+        package_version: ${{ steps.create-package.version }}
+        release_notes: ${{steps.fetch-release-notes.release_nodes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,8 @@ on:
 
   workflow_dispatch:
     inputs:
-      release-url:
-        description: "The URL of the github release which is being replicated in Octopus Deploy"
+      release-tag:
+        description: "The tag of the release being replicated in Octopus Deploy"
         required: true
 
 jobs:
@@ -48,10 +48,13 @@ jobs:
         id: fetch-release-nodes
         run: |
           if ["${{github.event_name}}" = "release"]; then
-             RELEASE_NOTES=curl -H "Accept: application/vnd.github.v3+json" ${{ github.event_path }} | jq '.body'
+             RELEASE_NOTES=`jq '.release.body' ${{ github.event_path }}
              echo "::set-output name=release-notes::$RELEASE_NOTES"
           else
-             RELEASE_NOTES=curl -H "Accept: application/vnd.github.v3+json" ${{ inputs.release-url }} | jq '.body'
+             RELEASE_URL="http://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/"${{inputs.release-tag}}
+             echo $RELEASE_URL
+             RELEASE_NOTES=curl -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq '
+          .body'
              echo "::set-output name=release-notes::$RELEASE_NOTES"
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
         run: |
           if ["${{github.event_name}}" = "release"]; then
              RELEASE_NOTES=curl ${{ github.event_path }} | jq '.body'
-             echo "::set-output name=release-notes::RELEASE_NOTES"
+             echo "::set-output name=release-notes::$RELEASE_NOTES"
           else
              RELEASE_NOTES=curl ${{ inputs.release-url }} | jq '.body'
-             echo "::set-output name=release-notes::RELEASE_NOTES"
+             echo "::set-output name=release-notes::$RELEASE_NOTES"
           fi
 
       - name: Create a release in Octopus Deploy 🐙

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       release-url:
-        description: "The URL of the github release being created in OD"
+        description: "The URL of the github release which is being replicated in Octopus Deploy"
         required: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,16 @@ jobs:
           VERSION=`./gradlew properties | grep ^version | awk '{print $2;}'`
           echo "::set-output name=version::$VERSION"
 
-      - name: Push a package to Octopus Deploy 🐙
-        uses: OctopusDeploy/push-package-action@v1.0.2
+      - name: Install Octopus CLI 🐙
+        uses: OctopusDeploy/install-octopus-cli-action@v1.1.7
         with:
-          overwrite_mode: IgnoreExists
+          version: latest
+
+
+      - name: Push a package to Octopus Deploy 🐙
+        uses: OctopusDeploy/push-package-action@v1.1.1
+        with:
+          overwrite_mode: IgnoreIfExists
           api_key: ${{ secrets.OCTOPUS_APIKEY }}
           packages: ${{ steps .create-package.package-created }}
           server: ${{ secrets.OCTOPUS_SERVER }}
@@ -51,7 +57,8 @@ jobs:
              RELEASE_NOTES=`jq '.release.body' ${{ github.event_path }}
              echo "::set-output name=release-notes::$RELEASE_NOTES"
           else
-             RELEASE_URL="http://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/"${{inputs.release-tag}}
+             RELEASE_URL=$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/"${{inputs
+          .release-tag}}
              echo $RELEASE_URL
              RELEASE_NOTES=curl -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq '
           .body'
@@ -59,7 +66,7 @@ jobs:
           fi
 
       - name: Create a release in Octopus Deploy 🐙
-        uses: OctopusDeploy/create-release-action@v1.0.2
+        uses: OctopusDeploy/create-release-action@v1.1.1
         with:
           api_key: ${{ secrets.OCTOPUS_APIKEY }}
           server: ${{ secrets.OCTOPUS_SERVER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,8 @@ jobs:
         id: create-package
         run: |
         ./gradlew distZip
-        echo "::set-output name=package-created::./gradlew -q packageName"
+        PACKAGE_NAME=`./gradlew -q packageName`
+        echo "::set-output name=package-created::$PACKAGE_NAME"
         version=`./gradlew properties | grep ^version | awk '{print $2;}'`
         echo "::set-output name=version::$version"
 
@@ -48,11 +49,11 @@ jobs:
       id: fetch-release-nodes
       run: |
         if ["${{github.event_name}}" = "release"]; then
-           release_notes=curl ${{ github.event_path }} | jq '.body'
-           echo "::set-output name=release_notes::$release_notes"
+           RELEASE_NOTES=curl ${{ github.event_path }} | jq '.body'
+           echo "::set-output name=release_notes::RELEASE_NOTES"
         else
-           release_notes=curl ${{ inputs.release-url }} | jq '.body'
-           echo "::set-output name=release_notes::$release_notes"
+           RELEASE_NOTES=curl ${{ inputs.release-url }} | jq '.body'
+           echo "::set-output name=release_notes::RELEASE_NOTES"
         fi
 
     - name: Create a release in Octopus Deploy 🐙

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,17 +41,17 @@ jobs:
         with:
           overwrite_mode: IgnoreExists
           api_key: ${{ secrets.OCTOPUS_APIKEY }}
-          packages: ${{ step.create-package.package-created }}
+          packages: ${{ steps .create-package.package-created }}
           server: ${{ secrets.OCTOPUS_SERVER }}
 
       - name: Fetch Release Notes
         id: fetch-release-nodes
         run: |
           if ["${{github.event_name}}" = "release"]; then
-             RELEASE_NOTES=curl ${{ github.event_path }} | jq '.body'
+             RELEASE_NOTES=curl -H "Accept: application/vnd.github.v3+json" ${{ github.event_path }} | jq '.body'
              echo "::set-output name=release-notes::$RELEASE_NOTES"
           else
-             RELEASE_NOTES=curl ${{ inputs.release-url }} | jq '.body'
+             RELEASE_NOTES=curl -H "Accept: application/vnd.github.v3+json" ${{ inputs.release-url }} | jq '.body'
              echo "::set-output name=release-notes::$RELEASE_NOTES"
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: Build, Test, Package and Push
 
-# Controls when the action will run.
 on:
   release:
     types: [created]
@@ -31,37 +30,37 @@ jobs:
       - name: Create Plugin Zip Deployment
         id: create-package
         run: |
-        ./gradlew distZip
-        PACKAGE_NAME=`./gradlew -q packageName`
-        echo "::set-output name=package-created::$PACKAGE_NAME"
-        version=`./gradlew properties | grep ^version | awk '{print $2;}'`
-        echo "::set-output name=version::$version"
+          ./gradlew distZip
+          PACKAGE_NAME=`./gradlew -q packageName`
+          echo "::set-output name=package-created::$PACKAGE_NAME"
+          VERSION=`./gradlew properties | grep ^version | awk '{print $2;}'`
+          echo "::set-output name=version::$VERSION"
 
-    - name: Push a package to Octopus Deploy 🐙
-      uses: OctopusDeploy/push-package-action@v1.0.2
-      with:
-        overwrite_mode: IgnoreExists
-        api_key: ${{ secrets.OCTOPUS_APIKEY }}
-        packages: ${{ step.create-package.package-created }}
-        server: ${{ secrets.OCTOPUS_SERVER }}
+      - name: Push a package to Octopus Deploy 🐙
+        uses: OctopusDeploy/push-package-action@v1.0.2
+        with:
+          overwrite_mode: IgnoreExists
+          api_key: ${{ secrets.OCTOPUS_APIKEY }}
+          packages: ${{ step.create-package.package-created }}
+          server: ${{ secrets.OCTOPUS_SERVER }}
 
-    - name: Fetch Release Notes
-      id: fetch-release-nodes
-      run: |
-        if ["${{github.event_name}}" = "release"]; then
-           RELEASE_NOTES=curl ${{ github.event_path }} | jq '.body'
-           echo "::set-output name=release_notes::RELEASE_NOTES"
-        else
-           RELEASE_NOTES=curl ${{ inputs.release-url }} | jq '.body'
-           echo "::set-output name=release_notes::RELEASE_NOTES"
-        fi
+      - name: Fetch Release Notes
+        id: fetch-release-nodes
+        run: |
+          if ["${{github.event_name}}" = "release"]; then
+             RELEASE_NOTES=curl ${{ github.event_path }} | jq '.body'
+             echo "::set-output name=release-notes::RELEASE_NOTES"
+          else
+             RELEASE_NOTES=curl ${{ inputs.release-url }} | jq '.body'
+             echo "::set-output name=release-notes::RELEASE_NOTES"
+          fi
 
-    - name: Create a release in Octopus Deploy 🐙
-      uses: OctopusDeploy/create-release-action@v1.0.2
-      with:
-        api_key: ${{ secrets.OCTOPUS_APIKEY }}
-        server: ${{ secrets.OCTOPUS_SERVER }}
-        space: "Integrations"
-        project: "TeamCity Plugin"
-        package_version: ${{ steps.create-package.version }}
-        release_notes: ${{steps.fetch-release-notes.release_nodes }}
+      - name: Create a release in Octopus Deploy 🐙
+        uses: OctopusDeploy/create-release-action@v1.0.2
+        with:
+          api_key: ${{ secrets.OCTOPUS_APIKEY }}
+          server: ${{ secrets.OCTOPUS_SERVER }}
+          space: "Integrations"
+          project: "TeamCity Plugin"
+          package_version: ${{ steps.create-package.version }}
+          release_notes: ${{steps.fetch-release-notes.release-notes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       with:
         api_key: ${{ secrets.OCTOPUS_APIKEY }}
         server: ${{ secrets.OCTOPUS_SERVER }}
-        space: "Spaces-62"
-        project: "teamcity-plugin"
+        space: "Integrations"
+        project: "TeamCity Plugin"
         package_version: ${{ steps.create-package.version }}
         release_notes: ${{steps.fetch-release-notes.release_nodes }}

--- a/build.gradle
+++ b/build.gradle
@@ -167,6 +167,12 @@ distributions {
   }
 }
 
+task packageName {
+  doFirst {
+    println tasks.findByPath(":distZip").outputs.files.singleFile
+  }
+}
+
 
 task deployLocal(type: Copy) {
   def teamCityDataDir = System.getenv("TEAMCITY_DATA_DIR") ?: System.getenv("HOME") + "/.BuildServer"


### PR DESCRIPTION
Added a github action which, when a release is created, creates a release in the Octopus server for the built package.

The github action can also be run manually - however a link to the Github release must be supplied.