### PR TITLE
Split ConnectionData from CommonStep Keys

### DIFF
--- a/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
@@ -14,7 +14,7 @@ import java.util.Iterator;
 
 import com.google.common.io.Resources;
 import net.lingala.zip4j.ZipFile;
-import octopus.teamcity.common.commonstep.CommonStepPropertyNames;
+import octopus.teamcity.common.connection.ConnectionPropertyNames;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.teamcity.rest.BuildAgent;
@@ -129,8 +129,8 @@ public class TeamCityFactory {
       final Path projectFilePath, final String httpEndpoint, final String apiKey)
       throws IOException {
     String projectContent = new String(Files.readAllBytes(projectFilePath), StandardCharsets.UTF_8);
-    projectContent = updateField(projectContent, CommonStepPropertyNames.SERVER_URL, httpEndpoint);
-    projectContent = updateField(projectContent, CommonStepPropertyNames.API_KEY, apiKey);
+    projectContent = updateField(projectContent, ConnectionPropertyNames.SERVER_URL, httpEndpoint);
+    projectContent = updateField(projectContent, ConnectionPropertyNames.API_KEY, apiKey);
 
     Files.write(projectFilePath, projectContent.getBytes(StandardCharsets.UTF_8));
   }

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/generic/OctopusGenericRunner.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/generic/OctopusGenericRunner.java
@@ -43,6 +43,7 @@ import octopus.teamcity.agent.pushpackage.OctopusPushPackageBuildProcess;
 import octopus.teamcity.agent.runbookrun.OctopusRunbookRunBuildProcess;
 import octopus.teamcity.common.OctopusConstants;
 import octopus.teamcity.common.commonstep.CommonStepUserData;
+import octopus.teamcity.common.connection.ConnectionUserData;
 
 public class OctopusGenericRunner implements AgentBuildRunner {
 
@@ -71,6 +72,8 @@ public class OctopusGenericRunner implements AgentBuildRunner {
     final BuildProgressLogger logger = runningBuild.getBuildLogger();
     final CommonStepUserData commonStepUserData =
         new CommonStepUserData(context.getRunnerParameters());
+    final ConnectionUserData connectionUserData =
+        new ConnectionUserData(context.getRunnerParameters());
 
     final String activityName = ACTIVITY_NAME + " - " + commonStepUserData.getStepType();
     logger.activityStarted(activityName, BLOCK_TYPE_BUILD_STEP);
@@ -78,8 +81,8 @@ public class OctopusGenericRunner implements AgentBuildRunner {
     try {
       logger.message(
           "Creating connection to Octopus server @ "
-              + commonStepUserData.getServerUrl().toString());
-      final ConnectData connection = TypeConverters.from(commonStepUserData);
+              + connectionUserData.getServerUrl().toString());
+      final ConnectData connection = TypeConverters.from(connectionUserData);
       final OctopusClient client = OctopusClientFactory.createClient(connection);
       return createBuildProcess(commonStepUserData.getStepType(), client, runningBuild, context);
     } catch (final MalformedURLException e) {

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/generic/TypeConverters.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/generic/TypeConverters.java
@@ -22,7 +22,7 @@ import com.octopus.sdk.http.ProxyData;
 
 import java.net.MalformedURLException;
 
-import octopus.teamcity.common.commonstep.CommonStepUserData;
+import octopus.teamcity.common.connection.ConnectionUserData;
 
 public class TypeConverters {
 
@@ -39,7 +39,7 @@ public class TypeConverters {
   }
 
   /** This assumes the userData contains correctly formatted strings * */
-  public static ConnectData from(final CommonStepUserData userData) throws MalformedURLException {
+  public static ConnectData from(final ConnectionUserData userData) throws MalformedURLException {
     final ConnectDataBuilder builder = new ConnectDataBuilder();
     builder.withOctopusServerUrl(userData.getServerUrl()).withApiKey(userData.getApiKey());
     if (userData.getProxyRequired()) {

--- a/octopus-common/src/main/java/octopus/teamcity/common/commonstep/CommonStepPropertyNames.java
+++ b/octopus-common/src/main/java/octopus/teamcity/common/commonstep/CommonStepPropertyNames.java
@@ -14,20 +14,11 @@
  */
 package octopus.teamcity.common.commonstep;
 
-import jetbrains.buildServer.agent.Constants;
-
 // NOTE: These constants must be accessible via getters to maintain bean-ness, which is used by jsps
 public class CommonStepPropertyNames {
 
   public static final String STEP_TYPE = "octopus_step_type";
-  public static final String SERVER_URL = "octopus_host";
-  public static final String API_KEY = Constants.SECURE_PROPERTY_PREFIX + "octopus_apikey";
   public static final String SPACE_NAME = "octopus_spacename";
-  public static final String PROXY_REQUIRED = "octopus_proxyrequired";
-  public static final String PROXY_URL = "octopus_proxyurl";
-  public static final String PROXY_USERNAME = "octopus_proxyusername";
-  public static final String PROXY_PASSWORD =
-      Constants.SECURE_PROPERTY_PREFIX + "octopus_proxypassword";
   public static final String VERBOSE_LOGGING = "octopus_verboselogging";
 
   public CommonStepPropertyNames() {}
@@ -36,32 +27,8 @@ public class CommonStepPropertyNames {
     return STEP_TYPE;
   }
 
-  public String getServerUrlPropertyName() {
-    return SERVER_URL;
-  }
-
-  public String getApiKeyPropertyName() {
-    return API_KEY;
-  }
-
   public String getSpaceNamePropertyName() {
     return SPACE_NAME;
-  }
-
-  public String getProxyRequiredPropertyName() {
-    return PROXY_REQUIRED;
-  }
-
-  public String getProxyServerUrlPropertyName() {
-    return PROXY_URL;
-  }
-
-  public String getProxyUsernamePropertyName() {
-    return PROXY_USERNAME;
-  }
-
-  public String getProxyPasswordPropertyName() {
-    return PROXY_PASSWORD;
   }
 
   public String getVerboseLoggingPropertyName() {

--- a/octopus-common/src/main/java/octopus/teamcity/common/commonstep/CommonStepUserData.java
+++ b/octopus-common/src/main/java/octopus/teamcity/common/commonstep/CommonStepUserData.java
@@ -15,8 +15,6 @@
 
 package octopus.teamcity.common.commonstep;
 
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.Map;
 import java.util.Optional;
 
@@ -39,35 +37,8 @@ public class CommonStepUserData extends BaseUserData {
     return fetchRaw(KEYS.getStepTypePropertyName());
   }
 
-  public URL getServerUrl() throws MalformedURLException {
-    final String rawInput = fetchRaw(KEYS.getServerUrlPropertyName());
-    return new URL(rawInput);
-  }
-
-  public String getApiKey() {
-    return fetchRaw(KEYS.getApiKeyPropertyName());
-  }
-
   public Optional<String> getSpaceName() {
     return Optional.ofNullable(params.get(KEYS.getSpaceNamePropertyName()));
-  }
-
-  public boolean getProxyRequired() {
-    final String rawInput = fetchRaw(KEYS.getProxyRequiredPropertyName());
-    return Boolean.getBoolean(rawInput);
-  }
-
-  public URL getProxyServerUrl() throws MalformedURLException {
-    final String rawInput = fetchRaw(KEYS.getProxyServerUrlPropertyName());
-    return new URL(rawInput);
-  }
-
-  public String getProxyUsername() {
-    return fetchRaw(KEYS.getProxyUsernamePropertyName());
-  }
-
-  public String getProxyPassword() {
-    return fetchRaw(KEYS.getProxyPasswordPropertyName());
   }
 
   public boolean getVerboseLogging() {

--- a/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionPropertyNames.java
+++ b/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionPropertyNames.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ *  these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package octopus.teamcity.common.connection;
+
+import jetbrains.buildServer.agent.Constants;
+
+// NOTE: These constants must be accessible via getters to maintain bean-ness, which is used by jsps
+public class ConnectionPropertyNames {
+
+  public static final String SERVER_URL = "octopus_host";
+  public static final String API_KEY = Constants.SECURE_PROPERTY_PREFIX + "octopus_apikey";
+  public static final String PROXY_REQUIRED = "octopus_proxyrequired";
+  public static final String PROXY_URL = "octopus_proxyurl";
+  public static final String PROXY_USERNAME = "octopus_proxyusername";
+  public static final String PROXY_PASSWORD =
+      Constants.SECURE_PROPERTY_PREFIX + "octopus_proxypassword";
+
+  public ConnectionPropertyNames() {}
+
+  public String getServerUrlPropertyName() {
+    return SERVER_URL;
+  }
+
+  public String getApiKeyPropertyName() {
+    return API_KEY;
+  }
+
+  public String getProxyRequiredPropertyName() {
+    return PROXY_REQUIRED;
+  }
+
+  public String getProxyServerUrlPropertyName() {
+    return PROXY_URL;
+  }
+
+  public String getProxyUsernamePropertyName() {
+    return PROXY_USERNAME;
+  }
+
+  public String getProxyPasswordPropertyName() {
+    return PROXY_PASSWORD;
+  }
+}

--- a/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionUserData.java
+++ b/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionUserData.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ *  these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package octopus.teamcity.common.connection;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+
+import octopus.teamcity.common.BaseUserData;
+
+/**
+ * Assumes that the params passed in are correctly formatted and can be immediate converted to the
+ * appropriate types (URL/Boolean), as the map was verified as part of the TeamCity
+ * PropertiesValidator
+ */
+public class ConnectionUserData extends BaseUserData {
+
+  private static final ConnectionPropertyNames KEYS = new ConnectionPropertyNames();
+
+  public ConnectionUserData(final Map<String, String> params) {
+    super(params);
+  }
+
+  public URL getServerUrl() throws MalformedURLException {
+    final String rawInput = fetchRaw(KEYS.getServerUrlPropertyName());
+    return new URL(rawInput);
+  }
+
+  public String getApiKey() {
+    return fetchRaw(KEYS.getApiKeyPropertyName());
+  }
+
+  public boolean getProxyRequired() {
+    final String rawInput = fetchRaw(KEYS.getProxyRequiredPropertyName());
+    return Boolean.getBoolean(rawInput);
+  }
+
+  public URL getProxyServerUrl() throws MalformedURLException {
+    final String rawInput = fetchRaw(KEYS.getProxyServerUrlPropertyName());
+    return new URL(rawInput);
+  }
+
+  public String getProxyUsername() {
+    return fetchRaw(KEYS.getProxyUsernamePropertyName());
+  }
+
+  public String getProxyPassword() {
+    return fetchRaw(KEYS.getProxyPasswordPropertyName());
+  }
+}

--- a/octopus-server/src/main/java/octopus/teamcity/server/generic/OctopusBuildStepPropertiesProcessor.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/generic/OctopusBuildStepPropertiesProcessor.java
@@ -27,9 +27,11 @@ import com.google.common.collect.Lists;
 import jetbrains.buildServer.serverSide.InvalidProperty;
 import jetbrains.buildServer.serverSide.PropertiesProcessor;
 import octopus.teamcity.common.commonstep.CommonStepPropertyNames;
+import octopus.teamcity.common.connection.ConnectionPropertyNames;
 
 public class OctopusBuildStepPropertiesProcessor implements PropertiesProcessor {
   private static final CommonStepPropertyNames KEYS = new CommonStepPropertyNames();
+  private static final ConnectionPropertyNames CONNECTION_KEYS = new ConnectionPropertyNames();
 
   @Override
   public List<InvalidProperty> process(final Map<String, String> properties) {
@@ -44,8 +46,9 @@ public class OctopusBuildStepPropertiesProcessor implements PropertiesProcessor 
 
     final List<InvalidProperty> result = Lists.newArrayList();
 
-    validateServerUrl(properties, KEYS.getServerUrlPropertyName()).ifPresent(result::add);
-    validateApiKey(properties, KEYS.getApiKeyPropertyName()).ifPresent(result::add);
+    validateServerUrl(properties, CONNECTION_KEYS.getServerUrlPropertyName())
+        .ifPresent(result::add);
+    validateApiKey(properties, CONNECTION_KEYS.getApiKeyPropertyName()).ifPresent(result::add);
     result.addAll(validateProxySettings(properties));
 
     final BuildStepCollection buildStepCollection = new BuildStepCollection();
@@ -100,11 +103,12 @@ public class OctopusBuildStepPropertiesProcessor implements PropertiesProcessor 
 
   private List<InvalidProperty> validateProxySettings(final Map<String, String> properties) {
     final List<InvalidProperty> result = Lists.newArrayList();
-    final String proxyRequired = properties.get(KEYS.getProxyRequiredPropertyName());
+    final String proxyRequired = properties.get(CONNECTION_KEYS.getProxyRequiredPropertyName());
     if (proxyRequired.equals("false")) {
       return result;
     }
-    validateProxyServerUrl(properties, KEYS.getProxyServerUrlPropertyName()).ifPresent(result::add);
+    validateProxyServerUrl(properties, CONNECTION_KEYS.getProxyServerUrlPropertyName())
+        .ifPresent(result::add);
     validateProxyCredentials(properties).ifPresent(result::add);
 
     return result;
@@ -126,20 +130,20 @@ public class OctopusBuildStepPropertiesProcessor implements PropertiesProcessor 
   }
 
   private Optional<InvalidProperty> validateProxyCredentials(final Map<String, String> properties) {
-    final String proxyUsername = properties.get(KEYS.getProxyUsernamePropertyName());
-    final String proxyPassword = properties.get(KEYS.getProxyPasswordPropertyName());
+    final String proxyUsername = properties.get(CONNECTION_KEYS.getProxyUsernamePropertyName());
+    final String proxyPassword = properties.get(CONNECTION_KEYS.getProxyPasswordPropertyName());
 
     if (proxyUsername == null && proxyPassword != null) {
       return Optional.of(
           new InvalidProperty(
-              KEYS.getProxyUsernamePropertyName(),
+              CONNECTION_KEYS.getProxyUsernamePropertyName(),
               "Proxy username must be set if password is provided"));
     }
 
     if (proxyUsername != null && proxyPassword == null) {
       return Optional.of(
           new InvalidProperty(
-              KEYS.getProxyPasswordPropertyName(),
+              CONNECTION_KEYS.getProxyPasswordPropertyName(),
               "Proxy password must be set if username is provided"));
     }
 

--- a/octopus-server/src/main/resources/buildServerResources/v2/editOctopusGeneric.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/v2/editOctopusGeneric.jsp
@@ -20,6 +20,8 @@
   ~ limitations under the License.
   --%>
 
+<jsp:useBean id="connectionKeys"
+             class="octopus.teamcity.common.connection.ConnectionPropertyNames"/>
 <jsp:useBean id="keys" class="octopus.teamcity.common.commonstep.CommonStepPropertyNames"/>
 <jsp:useBean id="propertiesBean" scope="request" type="jetbrains.buildServer.controllers.BasePropertiesBean"/>
 <jsp:useBean id="params" class="octopus.teamcity.server.generic.BuildStepCollection"/>
@@ -33,16 +35,16 @@
     <tr>
         <th>Octopus URL:<l:star/></th>
         <td>
-            <props:textProperty name="${keys.serverUrlPropertyName}" className="longField"/>
-            <span class="error" id="error_${keys.serverUrlPropertyName}"></span>
+            <props:textProperty name="${connectionKeys.serverUrlPropertyName}" className="longField"/>
+            <span class="error" id="error_${connectionKeys.serverUrlPropertyName}"></span>
             <span class="smallNote">Specify Octopus web portal URL</span>
         </td>
     </tr>
     <tr>
         <th>API key:<l:star/></th>
         <td>
-            <props:passwordProperty name="${keys.apiKeyPropertyName}" className="longField"/>
-            <span class="error" id="error_${keys.apiKeyPropertyName}"></span>
+            <props:passwordProperty name="${connectionKeys.apiKeyPropertyName}" className="longField"/>
+            <span class="error" id="error_${connectionKeys.apiKeyPropertyName}"></span>
             <span class="smallNote">Specify Octopus API key. You can get this from your user page in the Octopus web portal.</span>
         </td>
     </tr>
@@ -66,7 +68,7 @@
 </l:settingsGroup>
 
 <l:settingsGroup title="Proxy Server">
-    <props:selectSectionProperty name="${keys.proxyRequiredPropertyName}" title="Proxy Server Requried" note="">
+    <props:selectSectionProperty name="${connectionKeys.proxyRequiredPropertyName}" title="Proxy Server Requried" note="">
         <props:selectSectionPropertyContent value="false" caption="<No Proxy Required>"/>
             <props:selectSectionPropertyContent value="true" caption="Use Proxy Server">
                 <jsp:include page="${teamcityPluginResourcesPath}/v2/subpages/editProxyParameters.jsp"/>

--- a/octopus-server/src/main/resources/buildServerResources/v2/subpages/editProxyParameters.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/v2/subpages/editProxyParameters.jsp
@@ -20,7 +20,7 @@
   ~ limitations under the License.
   --%>
 
-<jsp:useBean id="keys" class="octopus.teamcity.common.commonstep.CommonStepPropertyNames"/>
+<jsp:useBean id="keys" class="octopus.teamcity.common.connection.ConnectionPropertyNames"/>
 <jsp:useBean id="params" class="octopus.teamcity.server.generic.BuildStepCollection"/>
 <jsp:useBean id="propertiesBean" scope="request" type="jetbrains.buildServer.controllers.BasePropertiesBean"/>
 
@@ -46,7 +46,7 @@
     <td>
         <props:passwordProperty name="${keys.proxyPasswordPropertyName}" className="longField"/>
         <span class="error" id="error_${keys.proxyPasswordPropertyName}"></span>
-        <span class="smallNote">Specify the password rqeuired to authenticate to the
+        <span class="smallNote">Specify the password required to authenticate to the
             proxy.</span>
     </td>
 </tr>

--- a/octopus-server/src/main/resources/buildServerResources/v2/viewOctopusGeneric.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/v2/viewOctopusGeneric.jsp
@@ -5,18 +5,20 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 
 <jsp:useBean id="teamcityPluginResourcesPath" scope="request" type="java.lang.String"/>
+<jsp:useBean id="connectionKeys"
+             class="octopus.teamcity.common.connection.ConnectionPropertyNames"/>
 <jsp:useBean id="keys" class="octopus.teamcity.common.commonstep.CommonStepPropertyNames"/>
 <jsp:useBean id="params" class="octopus.teamcity.server.generic.BuildStepCollection"/>
 <jsp:useBean id="propertiesBean" scope="request"
              type="jetbrains.buildServer.controllers.BasePropertiesBean"/>
 
 <c:set var="selectedOctopusVersion" value="${propertiesBean.properties['octopus_version']}"/>
-<c:set var="proxyServerUrl" value="${propertiesBean.properties[keys.proxyServerUrlPropertyName]}"/>
-<c:set var="proxyServerUser" value="${propertiesBean.properties[keys.proxyUsernamePropertyName]}"/>
+<c:set var="proxyServerUrl" value="${propertiesBean.properties[connectionKeys.proxyServerUrlPropertyName]}"/>
+<c:set var="proxyServerUser" value="${propertiesBean.properties[connectionKeys.proxyUsernamePropertyName]}"/>
 
 <div class="parameter">
     Octopus URL:
-    <strong><props:displayValue name="${keys.serverUrlPropertyName}" emptyValue="not specified"/></strong>
+    <strong><props:displayValue name="${connectionKeys.serverUrlPropertyName}" emptyValue="not specified"/></strong>
 </div>
 
 <div class="parameter">
@@ -26,20 +28,20 @@
 
 <div class="parameter">
     Proxy server required:
-    <strong><props:displayValue name="${keys.proxyRequiredPropertyName}" emptyValue="not specified"/></strong>
+    <strong><props:displayValue name="${connectionKeys.proxyRequiredPropertyName}" emptyValue="not specified"/></strong>
 </div>
 
 <c:if test="${proxyServerUrl ne null and proxyServerUrl ne ''}">
     <div class="parameter">
         Proxy server URL:
-        <strong><props:displayValue name="${keys.proxyServerUrlPropertyName}" emptyValue="not specified"/></strong>
+        <strong><props:displayValue name="${connectionKeys.proxyServerUrlPropertyName}" emptyValue="not specified"/></strong>
     </div>
 </c:if>
 
 <c:if test="${proxyServerUser ne null and proxyServerUser ne ''}">
     <div class="parameter">
         Proxy server username:
-        <strong><props:displayValue name="${keys.proxyUsernamePropertyName}" emptyValue="not specified"/></strong>
+        <strong><props:displayValue name="${connectionKeys.proxyUsernamePropertyName}" emptyValue="not specified"/></strong>
     </div>
 </c:if>
 

--- a/octopus-server/src/test/java/octopus/teamcity/server/generic/OctopusBuildStepPropertiesProcessorTest.java
+++ b/octopus-server/src/test/java/octopus/teamcity/server/generic/OctopusBuildStepPropertiesProcessorTest.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import jetbrains.buildServer.serverSide.InvalidProperty;
 import octopus.teamcity.common.buildinfo.BuildInfoPropertyNames;
 import octopus.teamcity.common.commonstep.CommonStepPropertyNames;
+import octopus.teamcity.common.connection.ConnectionPropertyNames;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -38,13 +39,13 @@ class OctopusBuildStepPropertiesProcessorTest {
   private Map<String, String> createValidPropertyMap() {
     final Map<String, String> result = new HashMap<>();
 
-    result.put(CommonStepPropertyNames.SERVER_URL, "http://localhost:8065");
-    result.put(CommonStepPropertyNames.API_KEY, "API-123456789012345678901234567890");
+    result.put(ConnectionPropertyNames.SERVER_URL, "http://localhost:8065");
+    result.put(ConnectionPropertyNames.API_KEY, "API-123456789012345678901234567890");
     result.put(CommonStepPropertyNames.SPACE_NAME, "My Space");
-    result.put(CommonStepPropertyNames.PROXY_REQUIRED, "true");
-    result.put(CommonStepPropertyNames.PROXY_URL, "http://proxy.url");
-    result.put(CommonStepPropertyNames.PROXY_USERNAME, "ProxyUsername");
-    result.put(CommonStepPropertyNames.PROXY_PASSWORD, "ProxyPassword");
+    result.put(ConnectionPropertyNames.PROXY_REQUIRED, "true");
+    result.put(ConnectionPropertyNames.PROXY_URL, "http://proxy.url");
+    result.put(ConnectionPropertyNames.PROXY_USERNAME, "ProxyUsername");
+    result.put(ConnectionPropertyNames.PROXY_PASSWORD, "ProxyPassword");
     result.put(CommonStepPropertyNames.STEP_TYPE, new BuildInformationStep().getName());
     result.put(CommonStepPropertyNames.VERBOSE_LOGGING, "false");
 
@@ -94,15 +95,15 @@ class OctopusBuildStepPropertiesProcessorTest {
     final OctopusBuildStepPropertiesProcessor processor = new OctopusBuildStepPropertiesProcessor();
     final Map<String, String> inputMap = createValidPropertyMap();
 
-    inputMap.remove(CommonStepPropertyNames.SERVER_URL);
-    inputMap.remove(CommonStepPropertyNames.API_KEY);
+    inputMap.remove(ConnectionPropertyNames.SERVER_URL);
+    inputMap.remove(ConnectionPropertyNames.API_KEY);
     final List<InvalidProperty> result = processor.process(inputMap);
     assertThat(result).hasSize(2);
     final List<String> missingPropertyNames =
         result.stream().map(InvalidProperty::getPropertyName).collect(Collectors.toList());
     assertThat(missingPropertyNames)
         .containsExactlyInAnyOrder(
-            CommonStepPropertyNames.SERVER_URL, CommonStepPropertyNames.API_KEY);
+            ConnectionPropertyNames.SERVER_URL, ConnectionPropertyNames.API_KEY);
   }
 
   @Test
@@ -110,10 +111,10 @@ class OctopusBuildStepPropertiesProcessorTest {
     final OctopusBuildStepPropertiesProcessor processor = new OctopusBuildStepPropertiesProcessor();
     final Map<String, String> inputMap = createValidPropertyMap();
 
-    inputMap.put(CommonStepPropertyNames.SERVER_URL, "badUrl");
+    inputMap.put(ConnectionPropertyNames.SERVER_URL, "badUrl");
     final List<InvalidProperty> result = processor.process(inputMap);
     assertThat(result).hasSize(1);
-    assertThat(result.get(0).getPropertyName()).isEqualTo(CommonStepPropertyNames.SERVER_URL);
+    assertThat(result.get(0).getPropertyName()).isEqualTo(ConnectionPropertyNames.SERVER_URL);
   }
 
   @Test
@@ -121,10 +122,10 @@ class OctopusBuildStepPropertiesProcessorTest {
     final OctopusBuildStepPropertiesProcessor processor = new OctopusBuildStepPropertiesProcessor();
     final Map<String, String> inputMap = createValidPropertyMap();
 
-    inputMap.put(CommonStepPropertyNames.API_KEY, "API-1");
+    inputMap.put(ConnectionPropertyNames.API_KEY, "API-1");
     final List<InvalidProperty> result = processor.process(inputMap);
     assertThat(result).hasSize(1);
-    assertThat(result.get(0).getPropertyName()).isEqualTo(CommonStepPropertyNames.API_KEY);
+    assertThat(result.get(0).getPropertyName()).isEqualTo(ConnectionPropertyNames.API_KEY);
   }
 
   @Test
@@ -143,8 +144,8 @@ class OctopusBuildStepPropertiesProcessorTest {
     final OctopusBuildStepPropertiesProcessor processor = new OctopusBuildStepPropertiesProcessor();
     final Map<String, String> inputMap = createValidPropertyMap();
 
-    inputMap.remove(CommonStepPropertyNames.PROXY_PASSWORD);
-    inputMap.remove(CommonStepPropertyNames.PROXY_USERNAME);
+    inputMap.remove(ConnectionPropertyNames.PROXY_PASSWORD);
+    inputMap.remove(ConnectionPropertyNames.PROXY_USERNAME);
     final List<InvalidProperty> result = processor.process(inputMap);
     assertThat(result).hasSize(0);
   }
@@ -154,10 +155,10 @@ class OctopusBuildStepPropertiesProcessorTest {
     final OctopusBuildStepPropertiesProcessor processor = new OctopusBuildStepPropertiesProcessor();
     final Map<String, String> inputMap = createValidPropertyMap();
 
-    inputMap.remove(CommonStepPropertyNames.PROXY_USERNAME);
+    inputMap.remove(ConnectionPropertyNames.PROXY_USERNAME);
     final List<InvalidProperty> result = processor.process(inputMap);
     assertThat(result).hasSize(1);
-    assertThat(result.get(0).getPropertyName()).isEqualTo(CommonStepPropertyNames.PROXY_USERNAME);
+    assertThat(result.get(0).getPropertyName()).isEqualTo(ConnectionPropertyNames.PROXY_USERNAME);
   }
 
   @Test
@@ -165,9 +166,9 @@ class OctopusBuildStepPropertiesProcessorTest {
     final OctopusBuildStepPropertiesProcessor processor = new OctopusBuildStepPropertiesProcessor();
     final Map<String, String> inputMap = createValidPropertyMap();
 
-    inputMap.remove(CommonStepPropertyNames.PROXY_PASSWORD);
+    inputMap.remove(ConnectionPropertyNames.PROXY_PASSWORD);
     final List<InvalidProperty> result = processor.process(inputMap);
     assertThat(result).hasSize(1);
-    assertThat(result.get(0).getPropertyName()).isEqualTo(CommonStepPropertyNames.PROXY_PASSWORD);
+    assertThat(result.get(0).getPropertyName()).isEqualTo(ConnectionPropertyNames.PROXY_PASSWORD);
   }
 }


### PR DESCRIPTION
Moves the connectionk based properties (url, apikey and proxy data) into its own class, allowing the connection data to ultimately be moved into a new form.