### PR TITLE
Introduce Controller in front of StepVnext Page

### DIFF
--- a/octopus-server/src/main/java/octopus/teamcity/server/OctopusGenericRunType.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/OctopusGenericRunType.java
@@ -75,7 +75,7 @@ public class OctopusGenericRunType extends RunType {
   @Override
   public String getEditRunnerParamsJspFilePath() {
     return pluginDescriptor.getPluginResourcesPath(
-        "v2" + File.separator + "editOctopusGeneric.jsp");
+        "v2" + File.separator + "editOctopusGeneric.html");
   }
 
   @Override

--- a/octopus-server/src/main/java/octopus/teamcity/server/generic/OctopusGenericRunTypeController.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/generic/OctopusGenericRunTypeController.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ *  these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package octopus.teamcity.server.generic;
+
+import java.io.File;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import jetbrains.buildServer.controllers.BaseController;
+import jetbrains.buildServer.web.openapi.PluginDescriptor;
+import jetbrains.buildServer.web.openapi.WebControllerManager;
+import octopus.teamcity.server.OctopusGenericRunType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.springframework.web.servlet.ModelAndView;
+
+// This is responsible for handling the call http request for the OctopusBuildStep.
+public class OctopusGenericRunTypeController extends BaseController {
+
+  private final PluginDescriptor pluginDescriptor;
+
+  public OctopusGenericRunTypeController(
+      final WebControllerManager webControllerManager,
+      final PluginDescriptor pluginDescriptor,
+      final OctopusGenericRunType octopusGenericRunType) {
+    this.pluginDescriptor = pluginDescriptor;
+
+    webControllerManager.registerController(
+        octopusGenericRunType.getEditRunnerParamsJspFilePath(), this);
+  }
+
+  @Nullable
+  @Override
+  protected ModelAndView doHandle(
+      @NotNull final HttpServletRequest request, @NotNull final HttpServletResponse response) {
+    return new ModelAndView(
+        pluginDescriptor.getPluginResourcesPath("v2" + File.separator + "editOctopusGeneric.jsp"));
+  }
+}

--- a/octopus-server/src/main/resources/META-INF/build-server-plugin-Octopus.TeamCity.xml
+++ b/octopus-server/src/main/resources/META-INF/build-server-plugin-Octopus.TeamCity.xml
@@ -16,4 +16,5 @@
     <bean class="octopus.teamcity.server.OctopusGenericRunType">
         <constructor-arg value="#{ systemProperties['octopus.enable.step.vnext'] }"/>
     </bean>
+    <bean class="octopus.teamcity.server.generic.OctopusGenericRunTypeController"/>
 </beans>


### PR DESCRIPTION
Teamcity allows RunTypes to explcitily specify the JSP file which represents their edit/view - or it is possible to put a Controller in front of the RuntType's view, which is responsible for producing the ModelAndView used to render the display.

This allows extra, computed, data to be added to the request, which can then be used by the JSP (thus the JSP can do more than just access static data).