### PR TITLE
Introduce Octopus Server connection, not yet used

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -25,6 +25,7 @@ dependencyManagement {
             entry 'agent-api'
             entry 'common-api'
             entry 'server-api'
+            entry 'oauth'
         }
         dependency 'org.jetbrains.teamcity:teamcity-rest-client:1.15.9999-SNAPSHOT'
 

--- a/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionPropertyNames.java
+++ b/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionPropertyNames.java
@@ -16,6 +16,7 @@ package octopus.teamcity.common.connection;
 
 import jetbrains.buildServer.agent.Constants;
 
+// NOTE: These constants must be accessible via getters to maintain bean-ness, which is used by jsps
 public class ConnectionPropertyNames {
   // DisplayName is _required_ by teamcity (and must be called "displayname")
   public static final String DISPLAY_NAME = "displayName";

--- a/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionPropertyNames.java
+++ b/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionPropertyNames.java
@@ -16,9 +16,9 @@ package octopus.teamcity.common.connection;
 
 import jetbrains.buildServer.agent.Constants;
 
-// NOTE: These constants must be accessible via getters to maintain bean-ness, which is used by jsps
 public class ConnectionPropertyNames {
-
+  // DisplayName is _required_ by teamcity (and must be called "displayname")
+  public static final String DISPLAY_NAME = "displayName";
   public static final String SERVER_URL = "octopus_host";
   public static final String API_KEY = Constants.SECURE_PROPERTY_PREFIX + "octopus_apikey";
   public static final String PROXY_REQUIRED = "octopus_proxyrequired";
@@ -28,6 +28,10 @@ public class ConnectionPropertyNames {
       Constants.SECURE_PROPERTY_PREFIX + "octopus_proxypassword";
 
   public ConnectionPropertyNames() {}
+
+  public String getDisplayName() {
+    return DISPLAY_NAME;
+  }
 
   public String getServerUrlPropertyName() {
     return SERVER_URL;

--- a/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionUserData.java
+++ b/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionUserData.java
@@ -21,11 +21,6 @@ import java.util.Map;
 
 import octopus.teamcity.common.BaseUserData;
 
-/**
- * Assumes that the params passed in are correctly formatted and can be immediate converted to the
- * appropriate types (URL/Boolean), as the map was verified as part of the TeamCity
- * PropertiesValidator
- */
 public class ConnectionUserData extends BaseUserData {
 
   private static final ConnectionPropertyNames KEYS = new ConnectionPropertyNames();

--- a/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionUserData.java
+++ b/octopus-common/src/main/java/octopus/teamcity/common/connection/ConnectionUserData.java
@@ -21,6 +21,11 @@ import java.util.Map;
 
 import octopus.teamcity.common.BaseUserData;
 
+/**
+ * Assumes that the params passed in are correctly formatted and can be immediate converted to the
+ * appropriate types (URL/Boolean), as the map was verified as part of the TeamCity
+ * PropertiesValidator
+ */
 public class ConnectionUserData extends BaseUserData {
 
   private static final ConnectionPropertyNames KEYS = new ConnectionPropertyNames();

--- a/octopus-server/build.gradle
+++ b/octopus-server/build.gradle
@@ -14,6 +14,7 @@ tasks.named('jar') {
 
 dependencies {
   provided 'org.jetbrains.teamcity:server-api'
+  provided 'org.jetbrains.teamcity:oauth'
 
   implementation project(':octopus-common')
   implementation 'com.octopus:octopus-sdk'

--- a/octopus-server/src/main/java/octopus/teamcity/server/connection/ConnectionHelper.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/connection/ConnectionHelper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ *  these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package octopus.teamcity.server.connection;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import jetbrains.buildServer.serverSide.ProjectManager;
+import jetbrains.buildServer.serverSide.auth.Permission;
+import jetbrains.buildServer.serverSide.oauth.OAuthConnectionDescriptor;
+import jetbrains.buildServer.serverSide.oauth.OAuthConnectionsManager;
+import jetbrains.buildServer.users.User;
+
+public class ConnectionHelper {
+
+  public static List<OAuthConnectionDescriptor> getAvailableOctopusConnections(
+      final OAuthConnectionsManager oauthConnectionManager,
+      final ProjectManager projectManager,
+      final User user) {
+    return projectManager.getProjects().stream()
+        .filter(p -> user.isPermissionGrantedForProject(p.getProjectId(), Permission.VIEW_PROJECT))
+        .map(p -> oauthConnectionManager.getAvailableConnectionsOfType(p, OctopusConnection.TYPE))
+        .flatMap(Collection::stream)
+        .filter(distinctByKey(OAuthConnectionDescriptor::getId))
+        .collect(Collectors.toList());
+  }
+
+  private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
+    Set<Object> seen = ConcurrentHashMap.newKeySet();
+    return t -> seen.add(keyExtractor.apply(t));
+  }
+}

--- a/octopus-server/src/main/java/octopus/teamcity/server/connection/ConnectionHelper.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/connection/ConnectionHelper.java
@@ -43,7 +43,7 @@ public class ConnectionHelper {
         .collect(Collectors.toList());
   }
 
-  private static <T> Predicate<T> distinctByKey(Function<? super T, ?> keyExtractor) {
+  private static <T> Predicate<T> distinctByKey(final Function<? super T, ?> keyExtractor) {
     Set<Object> seen = ConcurrentHashMap.newKeySet();
     return t -> seen.add(keyExtractor.apply(t));
   }

--- a/octopus-server/src/main/java/octopus/teamcity/server/connection/OctopusConnection.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/connection/OctopusConnection.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ *  these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package octopus.teamcity.server.connection;
+
+import java.net.MalformedURLException;
+import java.util.Map;
+
+import jetbrains.buildServer.serverSide.PropertiesProcessor;
+import jetbrains.buildServer.serverSide.oauth.OAuthConnectionDescriptor;
+import jetbrains.buildServer.serverSide.oauth.OAuthProvider;
+import jetbrains.buildServer.web.openapi.PluginDescriptor;
+import octopus.teamcity.common.connection.ConnectionUserData;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class OctopusConnection extends OAuthProvider {
+
+  public static final String TYPE = "OctopusConnection";
+
+  private final PluginDescriptor pluginDescriptor;
+
+  public OctopusConnection(final PluginDescriptor pluginDescriptor) {
+    this.pluginDescriptor = pluginDescriptor;
+  }
+
+  @NotNull
+  @Override
+  public String getType() {
+    return TYPE;
+  }
+
+  @NotNull
+  @Override
+  public String getDisplayName() {
+    return "OctopusDeploy Server";
+  }
+
+  @Override
+  @Nullable
+  public String getEditParametersUrl() {
+    return pluginDescriptor.getPluginResourcesPath("editOctopusConnection.jsp");
+  }
+
+  @Override
+  @NotNull
+  public String describeConnection(@NotNull OAuthConnectionDescriptor connection) {
+    final Map<String, String> params = connection.getParameters();
+    final ConnectionUserData userData = new ConnectionUserData(params);
+    try {
+      return String.format("Octopus Server URL: %s", userData.getServerUrl().toString());
+    } catch (MalformedURLException e) {
+      return "Unable to decode entered parameters.";
+    }
+  }
+
+  @Override
+  @Nullable
+  public PropertiesProcessor getPropertiesProcessor() {
+    return new OctopusConnectionPropertiesProcessor();
+  }
+}

--- a/octopus-server/src/main/java/octopus/teamcity/server/connection/OctopusConnection.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/connection/OctopusConnection.java
@@ -23,8 +23,6 @@ import jetbrains.buildServer.serverSide.oauth.OAuthConnectionDescriptor;
 import jetbrains.buildServer.serverSide.oauth.OAuthProvider;
 import jetbrains.buildServer.web.openapi.PluginDescriptor;
 import octopus.teamcity.common.connection.ConnectionUserData;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 public class OctopusConnection extends OAuthProvider {
 
@@ -36,27 +34,23 @@ public class OctopusConnection extends OAuthProvider {
     this.pluginDescriptor = pluginDescriptor;
   }
 
-  @NotNull
   @Override
   public String getType() {
     return TYPE;
   }
 
-  @NotNull
   @Override
   public String getDisplayName() {
     return "OctopusDeploy Server";
   }
 
   @Override
-  @Nullable
   public String getEditParametersUrl() {
     return pluginDescriptor.getPluginResourcesPath("editOctopusConnection.jsp");
   }
 
   @Override
-  @NotNull
-  public String describeConnection(@NotNull OAuthConnectionDescriptor connection) {
+  public String describeConnection(final OAuthConnectionDescriptor connection) {
     final Map<String, String> params = connection.getParameters();
     final ConnectionUserData userData = new ConnectionUserData(params);
     try {
@@ -67,7 +61,6 @@ public class OctopusConnection extends OAuthProvider {
   }
 
   @Override
-  @Nullable
   public PropertiesProcessor getPropertiesProcessor() {
     return new OctopusConnectionPropertiesProcessor();
   }

--- a/octopus-server/src/main/java/octopus/teamcity/server/connection/OctopusConnection.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/connection/OctopusConnection.java
@@ -41,7 +41,7 @@ public class OctopusConnection extends OAuthProvider {
 
   @Override
   public String getDisplayName() {
-    return "OctopusDeploy Server";
+    return "Octopus Deploy";
   }
 
   @Override

--- a/octopus-server/src/main/java/octopus/teamcity/server/connection/OctopusConnectionPropertiesProcessor.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/connection/OctopusConnectionPropertiesProcessor.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ *  these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package octopus.teamcity.server.connection;
+
+import com.octopus.sdk.utils.ApiKeyValidator;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.google.common.collect.Lists;
+import jetbrains.buildServer.serverSide.InvalidProperty;
+import jetbrains.buildServer.serverSide.PropertiesProcessor;
+import octopus.teamcity.common.connection.ConnectionPropertyNames;
+
+public class OctopusConnectionPropertiesProcessor implements PropertiesProcessor {
+  private static final ConnectionPropertyNames KEYS = new ConnectionPropertyNames();
+
+  @Override
+  public List<InvalidProperty> process(final Map<String, String> properties) {
+    if (properties == null) {
+      throw new IllegalArgumentException("Supplied properties list was null");
+    }
+
+    final List<InvalidProperty> result = Lists.newArrayList();
+
+    validateServerUrl(properties, KEYS.getServerUrlPropertyName()).ifPresent(result::add);
+    validateApiKey(properties, KEYS.getApiKeyPropertyName()).ifPresent(result::add);
+    result.addAll(validateProxySettings(properties));
+
+    return result;
+  }
+
+  private Optional<InvalidProperty> validateServerUrl(
+      final Map<String, String> properties, final String propertyId) {
+    final String serverUrl = properties.get(propertyId);
+
+    if (serverUrl == null) {
+      return Optional.of(new InvalidProperty(propertyId, "Server URL must be specified"));
+    } else {
+      try {
+        final URL octopusServerURL = new URL(serverUrl);
+        if (!octopusServerURL.getProtocol().equals("http")
+            && !octopusServerURL.getProtocol().equals("https")) {
+          return Optional.of(
+              new InvalidProperty(
+                  propertyId, "Server URL must specify specify http or https protocol"));
+        }
+      } catch (final MalformedURLException e) {
+        final String errorMsg = "Illegally formatted URL - " + e.getLocalizedMessage();
+        return Optional.of(new InvalidProperty(propertyId, errorMsg));
+      }
+    }
+    return Optional.empty();
+  }
+
+  private Optional<InvalidProperty> validateApiKey(
+      final Map<String, String> properties, final String propertyId) {
+    final String apiKey = properties.get(propertyId);
+    if (apiKey == null) {
+      return Optional.of(new InvalidProperty(propertyId, "API key must be specified"));
+    }
+
+    try {
+      ApiKeyValidator.validate(apiKey);
+    } catch (final IllegalArgumentException e) {
+      return Optional.of(new InvalidProperty(propertyId, e.getMessage()));
+    }
+    return Optional.empty();
+  }
+
+  private List<InvalidProperty> validateProxySettings(final Map<String, String> properties) {
+    final List<InvalidProperty> result = Lists.newArrayList();
+    final String proxyRequired = properties.get(KEYS.getProxyRequiredPropertyName());
+    if (proxyRequired.equals("false")) {
+      return result;
+    }
+    validateProxyServerUrl(properties, KEYS.getProxyServerUrlPropertyName()).ifPresent(result::add);
+    validateProxyCredentials(properties).ifPresent(result::add);
+
+    return result;
+  }
+
+  private Optional<InvalidProperty> validateProxyServerUrl(
+      final Map<String, String> properties, final String propertyId) {
+    final String proxyUrl = properties.get(propertyId);
+    if (proxyUrl == null) {
+      return Optional.of(new InvalidProperty(propertyId, "Proxy Server URL must be specified"));
+    } else {
+      try {
+        new URL(proxyUrl);
+      } catch (final MalformedURLException e) {
+        return Optional.of(new InvalidProperty(propertyId, e.getLocalizedMessage()));
+      }
+    }
+    return Optional.empty();
+  }
+
+  private Optional<InvalidProperty> validateProxyCredentials(final Map<String, String> properties) {
+    final String proxyUsername = properties.get(KEYS.getProxyUsernamePropertyName());
+    final String proxyPassword = properties.get(KEYS.getProxyPasswordPropertyName());
+
+    if (proxyUsername == null && proxyPassword != null) {
+      return Optional.of(
+          new InvalidProperty(
+              KEYS.getProxyUsernamePropertyName(),
+              "Proxy username must be set if password is provided"));
+    }
+
+    if (proxyUsername != null && proxyPassword == null) {
+      return Optional.of(
+          new InvalidProperty(
+              KEYS.getProxyPasswordPropertyName(),
+              "Proxy password must be set if username is provided"));
+    }
+
+    return Optional.empty();
+  }
+}

--- a/octopus-server/src/main/java/octopus/teamcity/server/connection/OctopusConnectionsBean.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/connection/OctopusConnectionsBean.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ *  these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package octopus.teamcity.server.connection;
+
+import java.util.List;
+
+import jetbrains.buildServer.serverSide.oauth.OAuthConnectionDescriptor;
+
+public class OctopusConnectionsBean {
+
+  private final List<OAuthConnectionDescriptor> connections;
+
+  public OctopusConnectionsBean(final List<OAuthConnectionDescriptor> connections) {
+    this.connections = connections;
+  }
+
+  public List<OAuthConnectionDescriptor> getConnections() {
+    return connections;
+  }
+}

--- a/octopus-server/src/main/resources/META-INF/build-server-plugin-Octopus.TeamCity.xml
+++ b/octopus-server/src/main/resources/META-INF/build-server-plugin-Octopus.TeamCity.xml
@@ -16,4 +16,5 @@
     <bean class="octopus.teamcity.server.OctopusGenericRunType">
         <constructor-arg value="#{ systemProperties['octopus.enable.step.vnext'] }"/>
     </bean>
+    <bean class="octopus.teamcity.server.connection.OctopusConnection"/>
 </beans>

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusConnection.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusConnection.jsp
@@ -34,7 +34,7 @@
         <td>
             <props:textProperty name="${keys.serverUrlPropertyName}" className="longField"/>
             <span class="error" id="error_${keys.serverUrlPropertyName}"></span>
-            <span class="smallNote">Specify Octopus web portal URL</span>
+            <span class="smallNote">Specify Octopus API key. You can get this from your user page in the Octopus web portal.</span>
         </td>
     </tr>
     <tr>

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusConnection.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusConnection.jsp
@@ -1,0 +1,57 @@
+<%@ include file="/include-internal.jsp" %>
+<%@ taglib prefix="props" tagdir="/WEB-INF/tags/props" %>
+<%@ taglib prefix="forms" tagdir="/WEB-INF/tags/forms" %>
+<%@ taglib prefix="l" tagdir="/WEB-INF/tags/layout" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+<%--
+  ~ Copyright (c) Octopus Deploy and contributors. All rights reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+  ~  these files except in compliance with the License. You may obtain a copy of the
+  ~ License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software distributed
+  ~ under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+  ~ CONDITIONS OF ANY KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations under the License.
+  --%>
+<jsp:useBean id="keys" class="octopus.teamcity.common.connection.ConnectionPropertyNames"/>
+
+<tr>
+    <th>Connection Name:</th>
+    <td>
+        <props:textProperty name="${keys.displayName}" className="longField"/>
+        <span class="error" id="error_displayName"></span>
+        <span class="smallNote">Provide some name to distinguish this connection from others.</span>
+    </td>
+</tr>
+<l:settingsGroup title="Server">
+    <tr>
+        <th>Octopus URL:<l:star/></th>
+        <td>
+            <props:textProperty name="${keys.serverUrlPropertyName}" className="longField"/>
+            <span class="error" id="error_${keys.serverUrlPropertyName}"></span>
+            <span class="smallNote">Specify Octopus web portal URL</span>
+        </td>
+    </tr>
+    <tr>
+        <th>API key:<l:star/></th>
+        <td>
+            <props:passwordProperty name="${keys.apiKeyPropertyName}" className="longField"/>
+            <span class="error" id="error_${keys.apiKeyPropertyName}"></span>
+            <span class="smallNote">Specify Octopus API key. You can get this from your user page in the Octopus web portal.</span>
+        </td>
+    </tr>
+</l:settingsGroup>
+
+<l:settingsGroup title="Proxy">
+    <props:selectSectionProperty name="${keys.proxyRequiredPropertyName}" title="Proxy Server Requried" note="">
+        <props:selectSectionPropertyContent value="false" caption="<No Proxy Required>"/>
+        <props:selectSectionPropertyContent value="true" caption="Use Proxy Server">
+            <jsp:include page="${teamcityPluginResourcesPath}/v2/subpages/editProxyParameters.jsp"/>
+        </props:selectSectionPropertyContent>
+    </props:selectSectionProperty>
+</l:settingsGroup>

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusConnection.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusConnection.jsp
@@ -34,7 +34,7 @@
         <td>
             <props:textProperty name="${keys.serverUrlPropertyName}" className="longField"/>
             <span class="error" id="error_${keys.serverUrlPropertyName}"></span>
-            <span class="smallNote">Specify Octopus API key. You can get this from your user page in the Octopus web portal.</span>
+            <span class="smallNote">Specify Octopus server URL (eg. http(s)://{hostname}:{port})</span>
         </td>
     </tr>
     <tr>


### PR DESCRIPTION
This creates an Octopus Server connection, which appears under the connections menu of a teamcity project.

This server is not used in any other feature, but lays the groundwork for future work (re-using said connection in build steps).