### PR TITLE
Update to 0.0.3-SNAPSHOT of SDK

### DIFF
--- a/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
@@ -68,7 +68,8 @@ public class BuildInformationEndToEndTest {
     final UserApi users = UserApi.create(client);
 
     final SpaceOverviewWithLinks newSpace =
-        new SpaceOverviewWithLinks(SPACE_NAME, singleton(users.getCurrentUser().getId()));
+        new SpaceOverviewWithLinks(
+            SPACE_NAME, singleton(users.getCurrentUser().getProperties().getId()));
     spaceOverviewApi.create(newSpace);
 
     // This is required to ensure docker container (run as tcuser) is able to write

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -2,7 +2,7 @@ dependencyManagement {
 
     dependencies {
 
-        dependencySet(group: 'com.octopus', version: '0.0.2-SNAPSHOT') {
+        dependencySet(group: 'com.octopus', version: '0.0.3-SNAPSHOT') {
             entry 'octopus-sdk'
             entry 'test-support'
         }

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/GenericUploadingBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/GenericUploadingBuildProcess.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) Octopus Deploy and contributors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ *  these files except in compliance with the License. You may obtain a copy of the
+ * License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package octopus.teamcity.agent;
+
+import com.octopus.sdk.model.commands.CommandBody;
+import com.octopus.sdk.operation.SpaceScopedOperation;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import jetbrains.buildServer.RunBuildException;
+import jetbrains.buildServer.agent.BuildFinishedStatus;
+import jetbrains.buildServer.agent.BuildRunnerContext;
+
+public abstract class GenericUploadingBuildProcess<T extends CommandBody>
+    extends InterruptableBuildProcess {
+
+  protected final SpaceScopedOperation<T, ?> operation;
+
+  public GenericUploadingBuildProcess(
+      final BuildRunnerContext context, final SpaceScopedOperation<T, ?> operation) {
+    super(context);
+    this.operation = operation;
+  }
+
+  @Override
+  public void doStart() throws RunBuildException {
+    buildLogger.message("Collating data for upload");
+    final Collection<T> parameters = collateParameters();
+
+    if (isInterrupted()) {
+      return;
+    }
+
+    buildLogger.message("Starting data upload");
+    if (upload(parameters)) {
+      complete(BuildFinishedStatus.FINISHED_SUCCESS);
+    } else {
+      complete(BuildFinishedStatus.FINISHED_FAILED);
+    }
+  }
+
+  protected boolean upload(final Collection<T> contexts) {
+    boolean uploadSucceeded = true;
+
+    final Iterator<T> it = contexts.iterator();
+    while (it.hasNext() && uploadSucceeded) {
+      uploadSucceeded = uploadItem(it.next());
+    }
+
+    it.forEachRemaining(context -> buildLogger.message(getIdentifier(context) + " -- SKIPPED"));
+
+    return uploadSucceeded;
+  }
+
+  protected boolean uploadItem(final T context) {
+    try {
+      operation.execute(context);
+      buildLogger.message(getIdentifier(context) + " -- UPLOADED");
+      return true;
+    } catch (final Throwable t) {
+      buildLogger.error(getIdentifier(context) + " -- FAILED");
+      buildLogger.buildFailureDescription(t.getMessage());
+      logStackTrace(t);
+      return false;
+    }
+  }
+
+  protected abstract Collection<T> collateParameters() throws RunBuildException;
+
+  protected abstract String getIdentifier(final T parameter);
+}

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
@@ -19,8 +19,6 @@ import com.octopus.sdk.operation.buildinformation.BuildInformationUploader;
 import com.octopus.sdk.operation.buildinformation.BuildInformationUploaderContext;
 import com.octopus.sdk.operation.buildinformation.BuildInformationUploaderContextBuilder;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
@@ -29,54 +27,26 @@ import java.util.stream.Collectors;
 
 import jetbrains.buildServer.RunBuildException;
 import jetbrains.buildServer.agent.AgentRunningBuild;
-import jetbrains.buildServer.agent.BuildFinishedStatus;
-import jetbrains.buildServer.agent.BuildProgressLogger;
 import jetbrains.buildServer.agent.BuildRunnerContext;
-import octopus.teamcity.agent.InterruptableBuildProcess;
+import octopus.teamcity.agent.GenericUploadingBuildProcess;
 import octopus.teamcity.agent.generic.TypeConverters;
 import octopus.teamcity.common.buildinfo.BuildInfoUserData;
 
-public class OctopusBuildInformationBuildProcess extends InterruptableBuildProcess {
+public class OctopusBuildInformationBuildProcess
+    extends GenericUploadingBuildProcess<BuildInformationUploaderContext> {
 
   private final BaseBuildVcsData buildVcsData;
-  private final BuildProgressLogger buildLogger;
-  private final BuildInformationUploader uploader;
 
   public OctopusBuildInformationBuildProcess(
       final BuildInformationUploader uploader,
       final BaseBuildVcsData buildVcsData,
       final BuildRunnerContext context) {
-    super(context);
-    this.uploader = uploader;
+    super(context, uploader);
     this.buildVcsData = buildVcsData;
-    this.buildLogger = context.getBuild().getBuildLogger();
   }
 
   @Override
-  public void doStart() throws RunBuildException {
-    try {
-      buildLogger.message("Collating data for upload");
-      final List<BuildInformationUploaderContext> buildInformationContexts =
-          collateBuildInformation();
-
-      if (isInterrupted()) {
-        complete(BuildFinishedStatus.INTERRUPTED);
-        return;
-      }
-
-      buildLogger.message("Starting data upload");
-      if (upload(buildInformationContexts)) {
-        complete(BuildFinishedStatus.FINISHED_SUCCESS);
-      } else {
-        complete(BuildFinishedStatus.FINISHED_FAILED);
-      }
-    } catch (final Throwable ex) {
-      throw new RunBuildException("Error processing build information build step.", ex);
-    }
-  }
-
-  public List<BuildInformationUploaderContext> collateBuildInformation()
-      throws MalformedURLException {
+  public List<BuildInformationUploaderContext> collateParameters() throws RunBuildException {
     final Map<String, String> parameters = context.getRunnerParameters();
     final AgentRunningBuild runningBuild = context.getBuild();
     final Map<String, String> sharedConfigParameters = runningBuild.getSharedConfigParameters();
@@ -84,21 +54,19 @@ public class OctopusBuildInformationBuildProcess extends InterruptableBuildProce
     final BuildInfoUserData buildInfoUserData = new BuildInfoUserData(parameters);
     final String buildId = Long.toString(runningBuild.getBuildId());
 
+    final URL buildUrl = constructBuildUrl(runningBuild, buildId);
+
     final BuildInformationUploaderContextBuilder buildInfoBuilder =
         new BuildInformationUploaderContextBuilder()
             .withBuildEnvironment("TeamCity")
-            .withSpaceName(buildInfoUserData.getSpaceName())
+            .withSpaceIdOrName(buildInfoUserData.getSpaceName())
             .withPackageVersion(buildInfoUserData.getPackageVersion())
             .withVcsType(sharedConfigParameters.get("octopus_vcstype"))
             .withVcsRoot(sharedConfigParameters.get("vcsroot.url"))
             .withVcsCommitNumber(sharedConfigParameters.get("build.vcs.number"))
             .withBranch(buildVcsData.getBranchName())
             .withCommits(buildVcsData.getCommits())
-            .withBuildUrl(
-                new URL(
-                    runningBuild.getAgentConfiguration().getServerUrl()
-                        + "/viewLog.html?buildId="
-                        + buildId))
+            .withBuildUrl(buildUrl)
             .withBuildNumber(runningBuild.getBuildNumber())
             .withOverwriteMode(TypeConverters.from(buildInfoUserData.getOverwriteMode()));
 
@@ -107,23 +75,20 @@ public class OctopusBuildInformationBuildProcess extends InterruptableBuildProce
         .collect(Collectors.toList());
   }
 
-  private boolean upload(final List<BuildInformationUploaderContext> buildInformationContexts) {
-    boolean allUploadsSuccessful = true;
-    for (final BuildInformationUploaderContext context : buildInformationContexts) {
-      buildLogger.message("Uploading " + context.getPackageId());
-      try {
-        uploader.upload(context);
-      } catch (final Throwable t) {
-        allUploadsSuccessful = false;
-        buildLogger.error("Upload of information failed for packageId: " + context.getPackageId());
-        buildLogger.error(t.getMessage());
-        final StringWriter sw = new StringWriter();
-        final PrintWriter pw = new PrintWriter(sw);
-        t.printStackTrace(pw);
-        buildLogger.debug(pw.toString());
-      }
-    }
+  private URL constructBuildUrl(final AgentRunningBuild runningBuild, final String buildId)
+      throws RunBuildException {
 
-    return allUploadsSuccessful;
+    final String buildUrlString =
+        runningBuild.getAgentConfiguration().getServerUrl() + "/viewLog.html?buildId=" + buildId;
+    try {
+      return new URL(buildUrlString);
+    } catch (final MalformedURLException e) {
+      throw new RunBuildException("Failed to construct a build URL from " + buildUrlString, e);
+    }
+  }
+
+  @Override
+  protected String getIdentifier(final BuildInformationUploaderContext parameter) {
+    return parameter.getPackageId();
   }
 }

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/createrelease/OctopusCreateReleaseBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/createrelease/OctopusCreateReleaseBuildProcess.java
@@ -1,48 +1,41 @@
 package octopus.teamcity.agent.createrelease;
 
+import static java.util.Collections.singletonList;
+
 import com.octopus.sdk.model.commands.CreateReleaseCommandBody;
 import com.octopus.sdk.operation.executionapi.CreateRelease;
 
+import java.util.Collection;
+
 import jetbrains.buildServer.RunBuildException;
-import jetbrains.buildServer.agent.BuildFinishedStatus;
-import jetbrains.buildServer.agent.BuildProgressLogger;
 import jetbrains.buildServer.agent.BuildRunnerContext;
-import octopus.teamcity.agent.InterruptableBuildProcess;
+import octopus.teamcity.agent.GenericUploadingBuildProcess;
 import octopus.teamcity.common.createrelease.CreateReleaseUserData;
 
-public class OctopusCreateReleaseBuildProcess extends InterruptableBuildProcess {
-
-  private final BuildProgressLogger buildLogger;
-  final CreateRelease executor;
+public class OctopusCreateReleaseBuildProcess
+    extends GenericUploadingBuildProcess<CreateReleaseCommandBody> {
 
   public OctopusCreateReleaseBuildProcess(
       final BuildRunnerContext context, final CreateRelease executor) {
-    super(context);
-    this.buildLogger = context.getBuild().getBuildLogger();
-    this.executor = executor;
+    super(context, executor);
   }
 
   @Override
-  public void doStart() throws RunBuildException {
-    try {
-      buildLogger.message("Collating data for Create Release");
-      final CreateReleaseUserData userData =
-          new CreateReleaseUserData(context.getRunnerParameters());
+  protected Collection<CreateReleaseCommandBody> collateParameters() throws RunBuildException {
+    final CreateReleaseUserData userData = new CreateReleaseUserData(context.getRunnerParameters());
 
-      final CreateReleaseCommandBody body =
-          new CreateReleaseCommandBody(
-              userData.getSpaceName(), userData.getProjectName(), userData.getPackageVersion());
-      userData.getReleaseVersion().ifPresent(body::setReleaseVersion);
-      userData.getChannelName().ifPresent(body::setChannelIdOrName);
-      body.setPackages(userData.getPackages());
+    final CreateReleaseCommandBody body =
+        new CreateReleaseCommandBody(
+            userData.getSpaceName(), userData.getProjectName(), userData.getPackageVersion());
+    userData.getReleaseVersion().ifPresent(body::setReleaseVersion);
+    userData.getChannelName().ifPresent(body::setChannelIdOrName);
+    body.setPackages(userData.getPackages());
 
-      buildLogger.message("Creating release");
-      final String response = executor.execute(body);
-      buildLogger.message("Release has been created: " + response);
+    return singletonList(body);
+  }
 
-      complete(BuildFinishedStatus.FINISHED_SUCCESS);
-    } catch (final Throwable ex) {
-      throw new RunBuildException("Error processing build information build step.", ex);
-    }
+  @Override
+  protected String getIdentifier(final CreateReleaseCommandBody parameter) {
+    return parameter.getReleaseVersion();
   }
 }

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/generic/OctopusGenericRunner.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/generic/OctopusGenericRunner.java
@@ -105,12 +105,12 @@ public class OctopusGenericRunner implements AgentBuildRunner {
     switch (stepType) {
       case ("build-information"):
         final BuildInformationUploader buildInformationUploader =
-            BuildInformationUploader.create(client);
+            new BuildInformationUploader(client);
         final BaseBuildVcsData buildVcsData = BuildVcsData.create(runningBuild);
         return new OctopusBuildInformationBuildProcess(
             buildInformationUploader, buildVcsData, context);
       case ("push-package"):
-        final PushPackageUploader pushPackageUploader = PushPackageUploader.create(client);
+        final PushPackageUploader pushPackageUploader = new PushPackageUploader(client);
         final FileSelector fileSelector = new FileSelector(context.getWorkingDirectory().toPath());
         return new OctopusPushPackageBuildProcess(pushPackageUploader, fileSelector, context);
       case ("create-release"):

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/runbookrun/OctopusRunbookRunBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/runbookrun/OctopusRunbookRunBuildProcess.java
@@ -1,63 +1,69 @@
 package octopus.teamcity.agent.runbookrun;
 
+import static java.util.Collections.singletonList;
+
 import com.octopus.sdk.model.commands.ExecuteRunbookCommandBody;
 import com.octopus.sdk.model.task.TaskState;
 import com.octopus.sdk.operation.executionapi.ExecuteRunbook;
 
-import jetbrains.buildServer.RunBuildException;
-import jetbrains.buildServer.agent.BuildFinishedStatus;
-import jetbrains.buildServer.agent.BuildProgressLogger;
+import java.util.Collection;
+
 import jetbrains.buildServer.agent.BuildRunnerContext;
-import octopus.teamcity.agent.InterruptableBuildProcess;
+import octopus.teamcity.agent.GenericUploadingBuildProcess;
 import octopus.teamcity.common.runbookrun.RunbookRunUserData;
 
-public class OctopusRunbookRunBuildProcess extends InterruptableBuildProcess {
+public class OctopusRunbookRunBuildProcess
+    extends GenericUploadingBuildProcess<ExecuteRunbookCommandBody> {
 
-  private final BuildProgressLogger buildLogger;
   private final ExecuteRunbook executor;
   private final TaskWaiter waiter;
 
   public OctopusRunbookRunBuildProcess(
       final BuildRunnerContext context, final ExecuteRunbook executor, final TaskWaiter waiter) {
-    super(context);
-    this.buildLogger = context.getBuild().getBuildLogger();
-    this.waiter = waiter;
+    super(context, executor);
     this.executor = executor;
+    this.waiter = waiter;
   }
 
   @Override
-  public void doStart() throws RunBuildException {
+  protected boolean uploadItem(final ExecuteRunbookCommandBody parameters) {
     try {
-      buildLogger.message("Collating data for Execute Runbook");
-      final RunbookRunUserData userData = new RunbookRunUserData(context.getRunnerParameters());
-      final String spaceName = userData.getSpaceName();
-
-      final ExecuteRunbookCommandBody body =
-          new ExecuteRunbookCommandBody(
-              spaceName,
-              userData.getProjectName(),
-              userData.getEnvironmentNames(),
-              userData.getRunbookName());
-      userData.getSnapshotName().ifPresent(body::setSnapshot);
-
-      final String serverTaskId = executor.execute(body);
+      final String serverTaskId = executor.execute(parameters);
+      buildLogger.message(getIdentifier(parameters) + " -- Executing");
 
       buildLogger.message(
           "Server task with id '"
               + serverTaskId
               + "' has been started for runbook '"
-              + userData.getRunbookName());
+              + getIdentifier(parameters));
 
       final TaskState taskCompletionState = waiter.waitForCompletion(serverTaskId);
 
-      if (taskCompletionState.equals(TaskState.SUCCESS)) {
-        complete(BuildFinishedStatus.FINISHED_SUCCESS);
-      } else {
-        complete(BuildFinishedStatus.FINISHED_FAILED);
-      }
-    } catch (final Throwable ex) {
-      throw new RunBuildException("Error processing build information build step.", ex);
+      return taskCompletionState.equals(TaskState.SUCCESS);
+    } catch (final Throwable t) {
+      throw new RuntimeException("Oh noes");
     }
+  }
+
+  @Override
+  protected Collection<ExecuteRunbookCommandBody> collateParameters() {
+    final RunbookRunUserData userData = new RunbookRunUserData(context.getRunnerParameters());
+    final String spaceName = userData.getSpaceName();
+
+    final ExecuteRunbookCommandBody body =
+        new ExecuteRunbookCommandBody(
+            spaceName,
+            userData.getProjectName(),
+            userData.getEnvironmentNames(),
+            userData.getRunbookName());
+    userData.getSnapshotName().ifPresent(body::setSnapshot);
+
+    return singletonList(body);
+  }
+
+  @Override
+  protected String getIdentifier(final ExecuteRunbookCommandBody parameters) {
+    return parameters.getRunbookName();
   }
 
   @Override

--- a/octopus-agent/src/test/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcessTest.java
+++ b/octopus-agent/src/test/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcessTest.java
@@ -37,6 +37,7 @@ import jetbrains.buildServer.agent.BuildProgressLogger;
 import jetbrains.buildServer.agent.BuildRunnerContext;
 import octopus.teamcity.common.OverwriteMode;
 import octopus.teamcity.common.buildinfo.BuildInfoPropertyNames;
+import octopus.teamcity.common.commonstep.CommonStepPropertyNames;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -56,6 +57,7 @@ class OctopusBuildInformationBuildProcessTest {
         BuildInfoPropertyNames.OVERWRITE_MODE, OverwriteMode.OverwriteExisting.name());
     userEnteredData.put(BuildInfoPropertyNames.PACKAGE_VERSION, "1.0");
     userEnteredData.put(BuildInfoPropertyNames.PACKAGE_IDS, "mypackage.first\nmypackage.second");
+    userEnteredData.put(CommonStepPropertyNames.SPACE_NAME, "TheSpace");
 
     final Map<String, String> sharedConfigParameters = new HashMap<>();
     sharedConfigParameters.put("octopus_vcstype", "git");
@@ -72,7 +74,7 @@ class OctopusBuildInformationBuildProcessTest {
     when(vcsData.getCommits()).thenReturn(Collections.emptyList());
     when(context.getRunnerParameters()).thenReturn(userEnteredData);
     when(context.getBuild()).thenReturn(mockBuild);
-    when(uploader.upload(any())).thenReturn("12345");
+    when(uploader.execute(any())).thenReturn("12345");
 
     final OctopusBuildInformationBuildProcess buildProcess =
         new OctopusBuildInformationBuildProcess(uploader, vcsData, context);
@@ -82,7 +84,7 @@ class OctopusBuildInformationBuildProcessTest {
 
     final ArgumentCaptor<BuildInformationUploaderContext> contextCaptor =
         ArgumentCaptor.forClass(BuildInformationUploaderContext.class);
-    verify(uploader, times(2)).upload(contextCaptor.capture());
+    verify(uploader, times(2)).execute(contextCaptor.capture());
 
     assertThat(contextCaptor.getAllValues().get(0).getBranch().get())
         .isEqualTo(vcsData.getBranchName());

--- a/octopus-agent/src/test/java/octopus/teamcity/agent/pushpackage/OctopusPushPackageBuildProcessTest.java
+++ b/octopus-agent/src/test/java/octopus/teamcity/agent/pushpackage/OctopusPushPackageBuildProcessTest.java
@@ -44,6 +44,7 @@ import jetbrains.buildServer.agent.BuildFinishedStatus;
 import jetbrains.buildServer.agent.BuildProgressLogger;
 import jetbrains.buildServer.agent.BuildRunnerContext;
 import octopus.teamcity.common.OverwriteMode;
+import octopus.teamcity.common.commonstep.CommonStepPropertyNames;
 import octopus.teamcity.common.pushpackage.PushPackagePropertyNames;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,6 +79,7 @@ class OctopusPushPackageBuildProcessTest {
         PushPackagePropertyNames.OVERWRITE_MODE, OverwriteMode.OverwriteExisting.name());
     userEnteredData.put(PushPackagePropertyNames.PACKAGE_PATHS, "*.zip");
     userEnteredData.put(PushPackagePropertyNames.USE_DELTA_COMPRESSION, "false");
+    userEnteredData.put(CommonStepPropertyNames.SPACE_NAME, "TheSpace");
 
     when(fileSelector.getMatchingFiles(any())).thenReturn(matchedFiles);
 
@@ -92,7 +94,7 @@ class OctopusPushPackageBuildProcessTest {
 
     final ArgumentCaptor<PushPackageUploaderContext> uploadPayload =
         ArgumentCaptor.forClass(PushPackageUploaderContext.class);
-    verify(uploader).upload(uploadPayload.capture());
+    verify(uploader).execute(uploadPayload.capture());
 
     assertThat(uploadPayload.getValue().getFile()).isEqualTo(toUpload);
     assertThat(uploadPayload.getValue().getOverwriteMode())
@@ -113,6 +115,7 @@ class OctopusPushPackageBuildProcessTest {
         PushPackagePropertyNames.OVERWRITE_MODE, OverwriteMode.OverwriteExisting.name());
     userEnteredData.put(PushPackagePropertyNames.PACKAGE_PATHS, "*.zip");
     userEnteredData.put(PushPackagePropertyNames.USE_DELTA_COMPRESSION, "false");
+    userEnteredData.put(CommonStepPropertyNames.SPACE_NAME, "TheSpace");
 
     final OctopusPushPackageBuildProcess buildProcess =
         new OctopusPushPackageBuildProcess(uploader, fileSelector, context);
@@ -121,7 +124,7 @@ class OctopusPushPackageBuildProcessTest {
 
     final ArgumentCaptor<PushPackageUploaderContext> uploadPayload =
         ArgumentCaptor.forClass(PushPackageUploaderContext.class);
-    verify(uploader, times(fileCount)).upload(uploadPayload.capture());
+    verify(uploader, times(fileCount)).execute(uploadPayload.capture());
 
     final List<File> filesUploaded =
         uploadPayload.getAllValues().stream()

--- a/octopus-server/src/main/resources/buildServerResources/editOctopusConnection.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusConnection.jsp
@@ -25,7 +25,7 @@
     <td>
         <props:textProperty name="${keys.displayName}" className="longField"/>
         <span class="error" id="error_displayName"></span>
-        <span class="smallNote">Provide some name to distinguish this connection from others.</span>
+        <span class="smallNote">Provide a uniquely distinguishable name for this connection</span>
     </td>
 </tr>
 <l:settingsGroup title="Server">


### PR DESCRIPTION
This allows the agent side of step vnext to be generically written,
which ensures error handling etc. are common across all build step
types.