### PR TITLE
Trying to fix the issues with release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
           RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
           RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
-          echo "::set-output name=RELEASE_NOTES::LOCAL_RELEASE_NOTES"
+          echo "::set-output name=RELEASE_NOTES::RELEASE_NOTES"
 
       - name: Create a release in Octopus Deploy 🐙
         run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,15 +53,15 @@ jobs:
         run: |
           echo "::debug::${{github.event_name}}"
           if [[ "${{github.event_name}}" = "release" ]]; then
-             RELEASE_NOTES=`jq --raw-output '.release.body' ${{ github.event_path }}`
-             echo "::set-output name=release-notes::$RELEASE_NOTES"
+             LOCAL_RELEASE_NOTES=`jq --raw-output '.release.body' ${{ github.event_path }}`
           else
              RELEASE_URL=$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/${{github.event.inputs.release-tag}}
              echo "::debug::Fetching relesae from $RELEASE_URL"
-             RELEASE_NOTES=`curl -s -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq --raw-output '.body'`
-             echo "::debug::Release notes = $RELEASE_NOTES"
-             echo "::set-output name=release-notes::$RELEASE_NOTES"
+             LOCAL_RELEASE_NOTES=`curl -s -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq --raw-output '.body'`
           fi
+          echo "Release notes = $LOCAL_RELEASE_NOTES"
+          # Need to use env-var, not step outputs, to ensure multi-line is successful
+          echo "RELEASE_NOTES=$LOCAL_RELEASE_NOTES" >> $GITHUB_ENV
 
       - name: Create a release in Octopus Deploy 🐙
         uses: OctopusDeploy/create-release-action@v1.1.1
@@ -72,4 +72,4 @@ jobs:
           project: "TeamCity Plugin"
           package_version: ${{ steps.create-package.outputs.version }}
           release_number: ${{ steps.create-package.outputs.version }}
-          release_notes: ${{ steps.fetch-release-notes.outputs.release-notes }}
+          release_notes: ${{ env.RELEASE_NOTES }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,9 @@ jobs:
           RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
           RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
           RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
+          echo $RELEASE_NOTES
           echo "::set-output name=RELEASE_NOTES::$RELEASE_NOTES"
 
       - name: Create a release in Octopus Deploy 🐙
         run:
-          echo ${{ steps.fetch-release-notes.outputs.RELEASE_NOTES }}
+          echo "${{ steps.fetch-release-notes.outputs.RELEASE_NOTES }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           $LOCAL_RELEASE_NOTES
           EOF
           )
-          echo "MULTI_LINE_LOCAL_RELEASE_NOTES"
+          echo "$MULTI_LINE_LOCAL_RELEASE_NOTES"
           # Need to use env-var, not step outputs, to ensure multi-line is successful
           echo "RELEASE_NOTES=<<EOF" >> $GITHUB_ENV
           echo "$MULTI_LINE_LOCAL_RELEASE_NOTES" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,17 @@ jobs:
              echo "::debug::Fetching relesae from $RELEASE_URL"
              LOCAL_RELEASE_NOTES=`curl -s -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq --raw-output '.body'`
           fi
+          echo "local = $LOCAL_RELEASE_NOTES"
           MULTI_LINE_LOCAL_RELEASE_NOTES=$(cat << EOF
           $LOCAL_RELEASE_NOTES
           EOF
           )
-          echo "$MULTI_LINE_LOCAL_RELEASE_NOTES"
+          echo "EOF'd = $MULTI_LINE_LOCAL_RELEASE_NOTES"
           # Need to use env-var, not step outputs, to ensure multi-line is successful
-          echo "RELEASE_NOTES=<<EOF" >> $GITHUB_ENV
+          echo "RELEASE_NOTES=<<EOF" >> $GITHUB_ENVA
+          echo "in between"
           echo "$MULTI_LINE_LOCAL_RELEASE_NOTES" >> $GITHUB_ENV
+          echo "before EOF"
           echo "EOF" >> $GITHUB_ENV
 
       - name: Create a release in Octopus Deploy 🐙

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,26 +20,17 @@ jobs:
         run: |
           echo "::debug::${{github.event_name}}"
           if [[ "${{github.event_name}}" = "release" ]]; then
-             LOCAL_RELEASE_NOTES=`jq --raw-output '.release.body' ${{ github.event_path }}`
+             RELEASE_NOTES=`jq --raw-output '.release.body' ${{ github.event_path }}`
           else
              RELEASE_URL=$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/${{github.event.inputs.release-tag}}
              echo "::debug::Fetching relesae from $RELEASE_URL"
-             LOCAL_RELEASE_NOTES=`curl -s -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq --raw-output '.body'`
+             RELEASE_NOTES=`curl -s -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq --raw-output '.body'`
           fi
-          echo "local = $LOCAL_RELEASE_NOTES"
-          MULTI_LINE_LOCAL_RELEASE_NOTES=$(cat << EOF
-          $LOCAL_RELEASE_NOTES
-          EOF
-          )
-          echo "EOF'd = $MULTI_LINE_LOCAL_RELEASE_NOTES"
-          # Need to use env-var, not step outputs, to ensure multi-line is successful
-          echo "RELEASE_NOTES=<<EOF" >> $GITHUB_ENV
-          echo "in between"
-          echo "$MULTI_LINE_LOCAL_RELEASE_NOTES" >> $GITHUB_ENV
-          echo "before EOF"
-          echo "EOF" >> $GITHUB_ENV
-          echo "after EOF"
+          RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
+          RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
+          RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
+          echo "::set-output name=RELEASE_NOTES::LOCAL_RELEASE_NOTES"
 
       - name: Create a release in Octopus Deploy 🐙
         run:
-          echo ${{ env.RELEASE_NOTES }}
+          echo ${{ steps.fetch-release-notes.outputs.RELEASE_NOTES }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           )
           echo "EOF'd = $MULTI_LINE_LOCAL_RELEASE_NOTES"
           # Need to use env-var, not step outputs, to ensure multi-line is successful
-          echo "RELEASE_NOTES=<<EOF" >> $GITHUB_ENVA
+          echo "RELEASE_NOTES=<<EOF" >> $GITHUB_ENV
           echo "in between"
           echo "$MULTI_LINE_LOCAL_RELEASE_NOTES" >> $GITHUB_ENV
           echo "before EOF"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
           RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
           RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
-          echo "::set-output name=RELEASE_NOTES::RELEASE_NOTES"
+          echo "::set-output name=RELEASE_NOTES::$RELEASE_NOTES"
 
       - name: Create a release in Octopus Deploy 🐙
         run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   build:
+    name: "Push Package and Create Release"
+    runs-on: ubuntu-latest
+    steps:
       - name: Fetch Release Notes
         id: fetch-release-notes
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
           echo "$MULTI_LINE_LOCAL_RELEASE_NOTES" >> $GITHUB_ENV
           echo "before EOF"
           echo "EOF" >> $GITHUB_ENV
+          echo "after EOF"
 
       - name: Create a release in Octopus Deploy 🐙
         run:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,10 @@ jobs:
           fi
           echo "Release notes = $LOCAL_RELEASE_NOTES"
           # Need to use env-var, not step outputs, to ensure multi-line is successful
-          echo "RELEASE_NOTES=$LOCAL_RELEASE_NOTES" >> $GITHUB_ENV
+          echo "RELEASE_NOTES=<<EOF" >> $GITHUB_ENV
+          echo "$LOCAL_RELEASE_NOTES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Create a release in Octopus Deploy 🐙
         run:
-          echo ${{env.RELEASE_NOTES }}
+          echo ${{ env.RELEASE_NOTES }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,39 @@ jobs:
     name: "Push Package and Create Release"
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'adopt'
+
+      - name: Build with gradle
+        run: ./gradlew build test
+
+      - name: Create Plugin Zip Deployment
+        id: create-package
+        run: |
+          ./gradlew distZip
+          PACKAGE_NAME=`./gradlew -q packageName`
+          echo "::set-output name=package-created::$PACKAGE_NAME"
+          VERSION=`./gradlew properties | grep ^version | awk '{print $2;}'`
+          echo "::set-output name=version::$VERSION"
+
+      - name: Install Octopus CLI 🐙
+        uses: OctopusDeploy/install-octopus-cli-action@v1.1.7
+
+      - name: Push a package to Octopus Deploy 🐙
+        uses: OctopusDeploy/push-package-action@v1.1.1
+        with:
+          overwrite_mode: IgnoreIfExists
+          api_key: ${{ secrets.OCTOPUS_APIKEY }}
+          packages: "${{ steps.create-package.outputs.package-created }}"
+          server: ${{ secrets.OCTOPUS_SERVER }}
+          space: "Integrations"
+
       - name: Fetch Release Notes
         id: fetch-release-notes
         run: |
@@ -26,12 +59,19 @@ jobs:
              echo "::debug::Fetching relesae from $RELEASE_URL"
              RELEASE_NOTES=`curl -s -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq --raw-output '.body'`
           fi
+          # Need to map the EOL characters
           RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
           RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
           RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
-          echo $RELEASE_NOTES
-          echo "::set-output name=RELEASE_NOTES::$RELEASE_NOTES"
+          echo "::set-output name=release-notes::$RELEASE_NOTES"
 
       - name: Create a release in Octopus Deploy 🐙
-        run:
-          echo "${{ steps.fetch-release-notes.outputs.RELEASE_NOTES }}"
+        uses: OctopusDeploy/create-release-action@v1.1.1
+        with:
+          api_key: ${{ secrets.OCTOPUS_APIKEY }}
+          server: ${{ secrets.OCTOPUS_SERVER }}
+          space: "Integrations"
+          project: "TeamCity Plugin"
+          package_version: ${{ steps.create-package.outputs.version }}
+          release_number: ${{ steps.create-package.outputs.version }}
+          release_notes: ${{ steps.fetch-release-notes.outputs.release-notes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
              echo "::debug::Fetching relesae from $RELEASE_URL"
              LOCAL_RELEASE_NOTES=`curl -s -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq --raw-output '.body'`
           fi
-          echo "$LOCAL_RELEASE_NOTES"
           MULTI_LINE_LOCAL_RELEASE_NOTES=$(cat << EOF
           $LOCAL_RELEASE_NOTES
           EOF
           )
+          echo "MULTI_LINE_LOCAL_RELEASE_NOTES"
           # Need to use env-var, not step outputs, to ensure multi-line is successful
           echo "RELEASE_NOTES=<<EOF" >> $GITHUB_ENV
           echo "$MULTI_LINE_LOCAL_RELEASE_NOTES" >> $GITHUB_ENV

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,42 +12,6 @@ on:
 
 jobs:
   build:
-    name: "Push Package and Create Release"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-
-      - name: Set up JDK 8
-        uses: actions/setup-java@v2
-        with:
-          java-version: '8'
-          distribution: 'adopt'
-
-      - name: Build with gradle
-        run: ./gradlew build test
-
-      - name: Create Plugin Zip Deployment
-        id: create-package
-        run: |
-          ./gradlew distZip
-          PACKAGE_NAME=`./gradlew -q packageName`
-          echo "::set-output name=package-created::$PACKAGE_NAME"
-          VERSION=`./gradlew properties | grep ^version | awk '{print $2;}'`
-          echo "::set-output name=version::$VERSION"
-
-      - name: Install Octopus CLI 🐙
-        uses: OctopusDeploy/install-octopus-cli-action@v1.1.7
-
-      - name: Push a package to Octopus Deploy 🐙
-        uses: OctopusDeploy/push-package-action@v1.1.1
-        with:
-          overwrite_mode: IgnoreIfExists
-          api_key: ${{ secrets.OCTOPUS_APIKEY }}
-          packages: "${{ steps.create-package.outputs.package-created }}"
-          server: ${{ secrets.OCTOPUS_SERVER }}
-          space: "Integrations"
-
       - name: Fetch Release Notes
         id: fetch-release-notes
         run: |
@@ -64,12 +28,5 @@ jobs:
           echo "RELEASE_NOTES=$LOCAL_RELEASE_NOTES" >> $GITHUB_ENV
 
       - name: Create a release in Octopus Deploy 🐙
-        uses: OctopusDeploy/create-release-action@v1.1.1
-        with:
-          api_key: ${{ secrets.OCTOPUS_APIKEY }}
-          server: ${{ secrets.OCTOPUS_SERVER }}
-          space: "Integrations"
-          project: "TeamCity Plugin"
-          package_version: ${{ steps.create-package.outputs.version }}
-          release_number: ${{ steps.create-package.outputs.version }}
-          release_notes: ${{ env.RELEASE_NOTES }}
+        run:
+          echo ${{env.RELEASE_NOTES }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,18 +52,16 @@ jobs:
         id: fetch-release-notes
         run: |
           echo "::debug::${{github.event_name}}"
+          OUTPUT_FILE="release_notes.txt"
           if [[ "${{github.event_name}}" = "release" ]]; then
-             RELEASE_NOTES=`jq --raw-output '.release.body' ${{ github.event_path }}`
+           jq --raw-output '.release.body' ${{ github.event_path }} | sed 's#\r#  #g' > $OUTPUT_FILE
           else
              RELEASE_URL=$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/tags/${{github.event.inputs.release-tag}}
+             echo $RELEASE_URL
              echo "::debug::Fetching relesae from $RELEASE_URL"
-             RELEASE_NOTES=`curl -s -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq --raw-output '.body'`
+             curl -s -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq --raw-output '.body' | sed 's#\r#  #g' > $OUTPUT_FILE
           fi
-          # Need to map the EOL characters
-          RELEASE_NOTES="${RELEASE_NOTES//'%'/'%25'}"
-          RELEASE_NOTES="${RELEASE_NOTES//$'\n'/'%0A'}"
-          RELEASE_NOTES="${RELEASE_NOTES//$'\r'/'%0D'}"
-          echo "::set-output name=release-notes::$RELEASE_NOTES"
+          echo "::set-output name=release-note-file::$OUTPUT_FILE"
 
       - name: Create a release in Octopus Deploy 🐙
         uses: OctopusDeploy/create-release-action@v1.1.1
@@ -74,4 +72,4 @@ jobs:
           project: "TeamCity Plugin"
           package_version: ${{ steps.create-package.outputs.version }}
           release_number: ${{ steps.create-package.outputs.version }}
-          release_notes: ${{ steps.fetch-release-notes.outputs.release-notes }}
+          release_notes_file: ${{ steps.fetch-release-notes.outputs.release-note-file }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,14 @@ jobs:
              echo "::debug::Fetching relesae from $RELEASE_URL"
              LOCAL_RELEASE_NOTES=`curl -s -H "Accept: application/vnd.github.v3+json" $RELEASE_URL | jq --raw-output '.body'`
           fi
-          echo "Release notes = $LOCAL_RELEASE_NOTES"
+          echo "$LOCAL_RELEASE_NOTES"
+          MULTI_LINE_LOCAL_RELEASE_NOTES=$(cat << EOF
+          $LOCAL_RELEASE_NOTES
+          EOF
+          )
           # Need to use env-var, not step outputs, to ensure multi-line is successful
           echo "RELEASE_NOTES=<<EOF" >> $GITHUB_ENV
-          echo "$LOCAL_RELEASE_NOTES" >> $GITHUB_ENV
+          echo "$MULTI_LINE_LOCAL_RELEASE_NOTES" >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
       - name: Create a release in Octopus Deploy 🐙


### PR DESCRIPTION
When passing multi-line variables between steps, the EOL charcters need to be appropriately mapped - otherwise only the first line is passed - resulting in the current, unexpected behaviour.

This change replaces \r\n characters awith appropriate hex-values.