### PR TITLE
Only attach ConnectionData to build when Vnext enabled

### DIFF
--- a/octopus-server/src/main/java/octopus/teamcity/server/OctopusBuildInformationBuildStartProcessor.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/OctopusBuildInformationBuildStartProcessor.java
@@ -12,6 +12,7 @@ import jetbrains.buildServer.serverSide.SRunningBuild;
 import jetbrains.buildServer.serverSide.oauth.OAuthConnectionDescriptor;
 import jetbrains.buildServer.serverSide.oauth.OAuthConnectionsManager;
 import jetbrains.buildServer.users.SUser;
+import jetbrains.buildServer.util.StringUtil;
 import jetbrains.buildServer.vcs.VcsRootInstanceEntry;
 import octopus.teamcity.common.commonstep.CommonStepPropertyNames;
 import octopus.teamcity.server.connection.ConnectionHelper;

--- a/octopus-server/src/main/java/octopus/teamcity/server/OctopusBuildInformationBuildStartProcessor.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/OctopusBuildInformationBuildStartProcessor.java
@@ -3,8 +3,6 @@ package octopus.teamcity.server;
 import java.util.List;
 import java.util.Map;
 
-import com.intellij.openapi.util.text.StringUtil;
-import jdk.internal.org.jline.utils.Log;
 import jetbrains.buildServer.ExtensionHolder;
 import jetbrains.buildServer.serverSide.BuildStartContext;
 import jetbrains.buildServer.serverSide.BuildStartContextProcessor;
@@ -62,15 +60,7 @@ public class OctopusBuildInformationBuildStartProcessor implements BuildStartCon
 
   private void insertConnectionPropertiesIntoOctopusBuildSteps(
       final BuildStartContext buildStartContext) {
-    SUser user = buildStartContext.getBuild().getTriggeredBy().getUser();
-    if (user == null) {
-      user = buildStartContext.getBuild().getOwner();
-    }
-
-    if(user == null) {
-      Log.warn("Unable to determine user who triggered build - unable to append connection data to build.");
-    }
-
+    final SUser user = buildStartContext.getBuild().getTriggeredBy().getUser();
     final Map<String, OAuthConnectionDescriptor> allConnections =
         ConnectionHelper.getAvailableOctopusConnections(
             oAuthConnectionsManager, projectManager, user);


### PR DESCRIPTION
Not all builds have an associated User (eg scheduled build)- and therefore cannot necessarily find permissable projects.

This ensures the connections are only added to builds if the StepVNext feature flag is enabled.

Note: if said flag is enabled - the scheduled builds will fail.