### PR TITLE
Update for log4j to 2.16.0

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -2,12 +2,12 @@ dependencyManagement {
 
     dependencies {
 
-        dependencySet(group: 'com.octopus', version: '0.0.3') {
+        dependencySet(group: 'com.octopus', version: '0.0.4') {
             entry 'octopus-sdk'
             entry 'test-support'
         }
 
-        dependencySet(group: 'org.apache.logging.log4j', version: '2.15.0') {
+        dependencySet(group: 'org.apache.logging.log4j', version: '2.16.0') {
             entry 'log4j-api'
             entry 'log4j-core'
             entry 'log4j-slf4j-impl'


### PR DESCRIPTION
This updates the SDK to version 0.0.4 which ensures
it too is using 2.16.0 of log4j