### PR TITLE
Prepare for 6.1.8 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=6.1.8-SNAPSHOT
+version=6.1.8


### PR DESCRIPTION
Update log4j to 2.16.0 and Java Client (SDK) to 0.0.4, to mitigate DOS vulnerability, documented:

https://www.zdnet.com/article/second-log4j-vulnerability-found-apache-log4j-2-16-0-released/