### PR TITLE
Fixed an issue with the BuildURL value in the Build Information

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
   id 'com.github.ben-manes.versions' version '0.36.0'
   id 'com.github.hierynomus.license' version '0.16.1'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'net.ltgt.errorprone' version '1.3.0'
+  id 'net.ltgt.errorprone' version '2.0.0'
   id 'maven-publish'
   id 'java'
   id 'distribution'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=6.1.11
+version=6.1.12

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
@@ -89,7 +89,7 @@ public class OctopusBuildInformationBuildProcess extends OctopusBuildProcess {
               sharedConfigParameters.get("build.vcs.number"),
               restfulBuild.getBranch().getName(),
               createJsonCommitHistory(restfulBuild),
-              sharedConfigParameters.get("externalBuildURL"),
+              sharedConfigParameters.get("externalBuildUrl"),
               build.getBuildNumber());
 
       if (verboseLogging) {

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
@@ -82,6 +82,13 @@ public class OctopusBuildInformationBuildProcess extends OctopusBuildProcess {
               teamCityServerUrl, build.getAccessUser(), build.getAccessCode());
       final Build restfulBuild = teamCityServer.build(new BuildId(buildIdString));
 
+      final String buildNumber = restfulBuild.getBuildNumber();
+      String buildUrlString = sharedConfigParameters.get("externalBuildUrl");
+      if (buildUrlString == null) {
+        // if the Global settings don't have a Server URL then fall back to using the agent's configuration for the server's URL
+        buildUrlString = teamCityServerUrl + "/viewLog.html?buildId=" + buildNumber;
+      }
+
       final OctopusBuildInformation buildInformation =
           builder.build(
               sharedConfigParameters.get("octopus_vcstype"),
@@ -89,8 +96,8 @@ public class OctopusBuildInformationBuildProcess extends OctopusBuildProcess {
               sharedConfigParameters.get("build.vcs.number"),
               restfulBuild.getBranch().getName(),
               createJsonCommitHistory(restfulBuild),
-              sharedConfigParameters.get("externalBuildUrl"),
-              build.getBuildNumber());
+              buildUrlString,
+              buildNumber);
 
       if (verboseLogging) {
         buildLogger.message("Creating " + dataFile);

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
@@ -85,7 +85,8 @@ public class OctopusBuildInformationBuildProcess extends OctopusBuildProcess {
       final String buildNumber = restfulBuild.getBuildNumber();
       String buildUrlString = sharedConfigParameters.get("externalBuildUrl");
       if (buildUrlString == null) {
-        // if the Global settings don't have a Server URL then fall back to using the agent's configuration for the server's URL
+        // if the Global settings don't have a Server URL then fall back to using the agent's
+        // configuration for the server's URL
         buildUrlString = teamCityServerUrl + "/viewLog.html?buildId=" + buildNumber;
       }
 

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
@@ -40,146 +40,145 @@ import org.jetbrains.teamcity.rest.TeamCityInstanceFactory;
 
 public class OctopusBuildInformationBuildProcess extends OctopusBuildProcess {
 
-  private final File checkoutDir;
-  private final Map<String, String> sharedConfigParameters;
-  private final String teamCityServerUrl;
+    private final File checkoutDir;
+    private final Map<String, String> sharedConfigParameters;
+    private final String teamCityServerUrl;
 
-  public OctopusBuildInformationBuildProcess(
-      @NotNull AgentRunningBuild runningBuild, @NotNull BuildRunnerContext context) {
-    super(runningBuild, context);
+    public OctopusBuildInformationBuildProcess(
+            @NotNull AgentRunningBuild runningBuild, @NotNull BuildRunnerContext context) {
+        super(runningBuild, context);
 
-    checkoutDir = runningBuild.getCheckoutDirectory();
-    sharedConfigParameters = runningBuild.getSharedConfigParameters();
-    teamCityServerUrl = runningBuild.getAgentConfiguration().getServerUrl();
-  }
-
-  @Override
-  protected String getLogMessage() {
-    return "Pushing build information to Octopus server";
-  }
-
-  @Override
-  protected OctopusCommandBuilder createCommand() {
-
-    final BuildProgressLogger buildLogger = getLogger();
-
-    final Map<String, String> parameters = getContext().getRunnerParameters();
-    final OctopusConstants constants = OctopusConstants.Instance;
-    final Boolean verboseLogging =
-        Boolean.parseBoolean(parameters.get(constants.getVerboseLoggingKey()));
-
-    final String dataFile =
-        Paths.get(checkoutDir.getPath(), "octopus.buildinfo").toAbsolutePath().toString();
-
-    try {
-      AgentRunningBuild build = getContext().getBuild();
-
-      final OctopusBuildInformationBuilder builder = new OctopusBuildInformationBuilder();
-
-      final String buildIdString = Long.toString(build.getBuildId());
-      final TeamCityInstance teamCityServer =
-          TeamCityInstanceFactory.httpAuth(
-              teamCityServerUrl, build.getAccessUser(), build.getAccessCode());
-      final Build restfulBuild = teamCityServer.build(new BuildId(buildIdString));
-
-      final OctopusBuildInformation buildInformation =
-          builder.build(
-              sharedConfigParameters.get("octopus_vcstype"),
-              sharedConfigParameters.get("vcsroot.url"),
-              sharedConfigParameters.get("build.vcs.number"),
-              restfulBuild.getBranch().getName(),
-              createJsonCommitHistory(restfulBuild),
-              teamCityServerUrl,
-              buildIdString,
-              build.getBuildNumber());
-
-      if (verboseLogging) {
-        buildLogger.message("Creating " + dataFile);
-      }
-
-      final OctopusBuildInformationWriter writer =
-          new OctopusBuildInformationWriter(buildLogger, verboseLogging);
-      writer.writeToFile(buildInformation, dataFile);
-
-    } catch (Exception ex) {
-      buildLogger.error("Error processing comment messages " + ex);
-      return null;
+        checkoutDir = runningBuild.getCheckoutDirectory();
+        sharedConfigParameters = runningBuild.getSharedConfigParameters();
+        teamCityServerUrl = runningBuild.getAgentConfiguration().getServerUrl();
     }
 
-    return new OctopusCommandBuilder() {
-      @Override
-      protected String[] buildCommand(boolean masked) {
-        final ArrayList<String> commands = new ArrayList<String>();
-        final String serverUrl = parameters.get(constants.getServerKey());
-        final String apiKey = parameters.get(constants.getApiKey());
-        final String spaceName = parameters.get(constants.getSpaceName());
-        final String packageIds = parameters.get(constants.getPackageIdKey());
-        final String packageVersion = parameters.get(constants.getPackageVersionKey());
-        final String commandLineArguments = parameters.get(constants.getCommandLineArgumentsKey());
-
-        final String forcePush = parameters.get(constants.getForcePushKey());
-        OverwriteMode overwriteMode = OverwriteMode.FailIfExists;
-        if ("true".equals(forcePush)) {
-          overwriteMode = OverwriteMode.OverwriteExisting;
-        } else if (OverwriteMode.IgnoreIfExists.name().equals(forcePush)) {
-          overwriteMode = OverwriteMode.IgnoreIfExists;
-        }
-
-        if (verboseLogging) {
-          buildLogger.message("ForcePush: " + forcePush);
-          buildLogger.message("OverwriteMode: " + overwriteMode.name());
-        }
-
-        commands.add("build-information");
-        commands.add("--server");
-        commands.add(serverUrl);
-        commands.add("--apikey");
-        commands.add(masked ? "SECRET" : apiKey);
-
-        if (spaceName != null && !spaceName.isEmpty()) {
-          commands.add("--space");
-          commands.add(spaceName);
-        }
-
-        for (String packageId : StringUtil.split(packageIds, "\n")) {
-          commands.add("--package-id");
-          commands.add(packageId);
-        }
-
-        commands.add("--version");
-        commands.add(packageVersion);
-
-        commands.add("--file");
-        commands.add(dataFile);
-
-        if (overwriteMode != OverwriteMode.FailIfExists) {
-          commands.add("--overwrite-mode");
-          commands.add(overwriteMode.name());
-        }
-
-        if (commandLineArguments != null && !commandLineArguments.isEmpty()) {
-          commands.addAll(splitSpaceSeparatedValues(commandLineArguments));
-        }
-
-        return commands.toArray(new String[commands.size()]);
-      }
-    };
-  }
-
-  private String createJsonCommitHistory(final Build build) {
-    final List<Change> changes = build.fetchChanges();
-
-    final List<Commit> commits = new ArrayList<>();
-    for (Change change : changes) {
-
-      final Commit c = new Commit();
-      c.Id = change.getVersion();
-      c.Comment = change.getComment();
-
-      commits.add(c);
+    @Override
+    protected String getLogMessage() {
+        return "Pushing build information to Octopus server";
     }
 
-    final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
-    return gson.toJson(commits);
-  }
+    @Override
+    protected OctopusCommandBuilder createCommand() {
+
+        final BuildProgressLogger buildLogger = getLogger();
+
+        final Map<String, String> parameters = getContext().getRunnerParameters();
+        final OctopusConstants constants = OctopusConstants.Instance;
+        final Boolean verboseLogging =
+                Boolean.parseBoolean(parameters.get(constants.getVerboseLoggingKey()));
+
+        final String dataFile =
+                Paths.get(checkoutDir.getPath(), "octopus.buildinfo").toAbsolutePath().toString();
+
+        try {
+            AgentRunningBuild build = getContext().getBuild();
+
+            final OctopusBuildInformationBuilder builder = new OctopusBuildInformationBuilder();
+
+            final String buildIdString = Long.toString(build.getBuildId());
+            final TeamCityInstance teamCityServer =
+                    TeamCityInstanceFactory.httpAuth(
+                            teamCityServerUrl, build.getAccessUser(), build.getAccessCode());
+            final Build restfulBuild = teamCityServer.build(new BuildId(buildIdString));
+
+            final OctopusBuildInformation buildInformation =
+                    builder.build(
+                            sharedConfigParameters.get("octopus_vcstype"),
+                            sharedConfigParameters.get("vcsroot.url"),
+                            sharedConfigParameters.get("build.vcs.number"),
+                            restfulBuild.getBranch().getName(),
+                            createJsonCommitHistory(restfulBuild),
+                            sharedConfigParameters.get("externalBuildURL"),
+                            build.getBuildNumber());
+
+            if (verboseLogging) {
+                buildLogger.message("Creating " + dataFile);
+            }
+
+            final OctopusBuildInformationWriter writer =
+                    new OctopusBuildInformationWriter(buildLogger, verboseLogging);
+            writer.writeToFile(buildInformation, dataFile);
+
+        } catch (Exception ex) {
+            buildLogger.error("Error processing comment messages " + ex);
+            return null;
+        }
+
+        return new OctopusCommandBuilder() {
+            @Override
+            protected String[] buildCommand(boolean masked) {
+                final ArrayList<String> commands = new ArrayList<String>();
+                final String serverUrl = parameters.get(constants.getServerKey());
+                final String apiKey = parameters.get(constants.getApiKey());
+                final String spaceName = parameters.get(constants.getSpaceName());
+                final String packageIds = parameters.get(constants.getPackageIdKey());
+                final String packageVersion = parameters.get(constants.getPackageVersionKey());
+                final String commandLineArguments = parameters.get(constants.getCommandLineArgumentsKey());
+
+                final String forcePush = parameters.get(constants.getForcePushKey());
+                OverwriteMode overwriteMode = OverwriteMode.FailIfExists;
+                if ("true".equals(forcePush)) {
+                    overwriteMode = OverwriteMode.OverwriteExisting;
+                } else if (OverwriteMode.IgnoreIfExists.name().equals(forcePush)) {
+                    overwriteMode = OverwriteMode.IgnoreIfExists;
+                }
+
+                if (verboseLogging) {
+                    buildLogger.message("ForcePush: " + forcePush);
+                    buildLogger.message("OverwriteMode: " + overwriteMode.name());
+                }
+
+                commands.add("build-information");
+                commands.add("--server");
+                commands.add(serverUrl);
+                commands.add("--apikey");
+                commands.add(masked ? "SECRET" : apiKey);
+
+                if (spaceName != null && !spaceName.isEmpty()) {
+                    commands.add("--space");
+                    commands.add(spaceName);
+                }
+
+                for (String packageId : StringUtil.split(packageIds, "\n")) {
+                    commands.add("--package-id");
+                    commands.add(packageId);
+                }
+
+                commands.add("--version");
+                commands.add(packageVersion);
+
+                commands.add("--file");
+                commands.add(dataFile);
+
+                if (overwriteMode != OverwriteMode.FailIfExists) {
+                    commands.add("--overwrite-mode");
+                    commands.add(overwriteMode.name());
+                }
+
+                if (commandLineArguments != null && !commandLineArguments.isEmpty()) {
+                    commands.addAll(splitSpaceSeparatedValues(commandLineArguments));
+                }
+
+                return commands.toArray(new String[commands.size()]);
+            }
+        };
+    }
+
+    private String createJsonCommitHistory(final Build build) {
+        final List<Change> changes = build.fetchChanges();
+
+        final List<Commit> commits = new ArrayList<>();
+        for (Change change : changes) {
+
+            final Commit c = new Commit();
+            c.Id = change.getVersion();
+            c.Comment = change.getComment();
+
+            commits.add(c);
+        }
+
+        final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+        return gson.toJson(commits);
+    }
 }

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuildProcess.java
@@ -40,145 +40,145 @@ import org.jetbrains.teamcity.rest.TeamCityInstanceFactory;
 
 public class OctopusBuildInformationBuildProcess extends OctopusBuildProcess {
 
-    private final File checkoutDir;
-    private final Map<String, String> sharedConfigParameters;
-    private final String teamCityServerUrl;
+  private final File checkoutDir;
+  private final Map<String, String> sharedConfigParameters;
+  private final String teamCityServerUrl;
 
-    public OctopusBuildInformationBuildProcess(
-            @NotNull AgentRunningBuild runningBuild, @NotNull BuildRunnerContext context) {
-        super(runningBuild, context);
+  public OctopusBuildInformationBuildProcess(
+      @NotNull AgentRunningBuild runningBuild, @NotNull BuildRunnerContext context) {
+    super(runningBuild, context);
 
-        checkoutDir = runningBuild.getCheckoutDirectory();
-        sharedConfigParameters = runningBuild.getSharedConfigParameters();
-        teamCityServerUrl = runningBuild.getAgentConfiguration().getServerUrl();
+    checkoutDir = runningBuild.getCheckoutDirectory();
+    sharedConfigParameters = runningBuild.getSharedConfigParameters();
+    teamCityServerUrl = runningBuild.getAgentConfiguration().getServerUrl();
+  }
+
+  @Override
+  protected String getLogMessage() {
+    return "Pushing build information to Octopus server";
+  }
+
+  @Override
+  protected OctopusCommandBuilder createCommand() {
+
+    final BuildProgressLogger buildLogger = getLogger();
+
+    final Map<String, String> parameters = getContext().getRunnerParameters();
+    final OctopusConstants constants = OctopusConstants.Instance;
+    final Boolean verboseLogging =
+        Boolean.parseBoolean(parameters.get(constants.getVerboseLoggingKey()));
+
+    final String dataFile =
+        Paths.get(checkoutDir.getPath(), "octopus.buildinfo").toAbsolutePath().toString();
+
+    try {
+      AgentRunningBuild build = getContext().getBuild();
+
+      final OctopusBuildInformationBuilder builder = new OctopusBuildInformationBuilder();
+
+      final String buildIdString = Long.toString(build.getBuildId());
+      final TeamCityInstance teamCityServer =
+          TeamCityInstanceFactory.httpAuth(
+              teamCityServerUrl, build.getAccessUser(), build.getAccessCode());
+      final Build restfulBuild = teamCityServer.build(new BuildId(buildIdString));
+
+      final OctopusBuildInformation buildInformation =
+          builder.build(
+              sharedConfigParameters.get("octopus_vcstype"),
+              sharedConfigParameters.get("vcsroot.url"),
+              sharedConfigParameters.get("build.vcs.number"),
+              restfulBuild.getBranch().getName(),
+              createJsonCommitHistory(restfulBuild),
+              sharedConfigParameters.get("externalBuildURL"),
+              build.getBuildNumber());
+
+      if (verboseLogging) {
+        buildLogger.message("Creating " + dataFile);
+      }
+
+      final OctopusBuildInformationWriter writer =
+          new OctopusBuildInformationWriter(buildLogger, verboseLogging);
+      writer.writeToFile(buildInformation, dataFile);
+
+    } catch (Exception ex) {
+      buildLogger.error("Error processing comment messages " + ex);
+      return null;
     }
 
-    @Override
-    protected String getLogMessage() {
-        return "Pushing build information to Octopus server";
-    }
+    return new OctopusCommandBuilder() {
+      @Override
+      protected String[] buildCommand(boolean masked) {
+        final ArrayList<String> commands = new ArrayList<String>();
+        final String serverUrl = parameters.get(constants.getServerKey());
+        final String apiKey = parameters.get(constants.getApiKey());
+        final String spaceName = parameters.get(constants.getSpaceName());
+        final String packageIds = parameters.get(constants.getPackageIdKey());
+        final String packageVersion = parameters.get(constants.getPackageVersionKey());
+        final String commandLineArguments = parameters.get(constants.getCommandLineArgumentsKey());
 
-    @Override
-    protected OctopusCommandBuilder createCommand() {
-
-        final BuildProgressLogger buildLogger = getLogger();
-
-        final Map<String, String> parameters = getContext().getRunnerParameters();
-        final OctopusConstants constants = OctopusConstants.Instance;
-        final Boolean verboseLogging =
-                Boolean.parseBoolean(parameters.get(constants.getVerboseLoggingKey()));
-
-        final String dataFile =
-                Paths.get(checkoutDir.getPath(), "octopus.buildinfo").toAbsolutePath().toString();
-
-        try {
-            AgentRunningBuild build = getContext().getBuild();
-
-            final OctopusBuildInformationBuilder builder = new OctopusBuildInformationBuilder();
-
-            final String buildIdString = Long.toString(build.getBuildId());
-            final TeamCityInstance teamCityServer =
-                    TeamCityInstanceFactory.httpAuth(
-                            teamCityServerUrl, build.getAccessUser(), build.getAccessCode());
-            final Build restfulBuild = teamCityServer.build(new BuildId(buildIdString));
-
-            final OctopusBuildInformation buildInformation =
-                    builder.build(
-                            sharedConfigParameters.get("octopus_vcstype"),
-                            sharedConfigParameters.get("vcsroot.url"),
-                            sharedConfigParameters.get("build.vcs.number"),
-                            restfulBuild.getBranch().getName(),
-                            createJsonCommitHistory(restfulBuild),
-                            sharedConfigParameters.get("externalBuildURL"),
-                            build.getBuildNumber());
-
-            if (verboseLogging) {
-                buildLogger.message("Creating " + dataFile);
-            }
-
-            final OctopusBuildInformationWriter writer =
-                    new OctopusBuildInformationWriter(buildLogger, verboseLogging);
-            writer.writeToFile(buildInformation, dataFile);
-
-        } catch (Exception ex) {
-            buildLogger.error("Error processing comment messages " + ex);
-            return null;
+        final String forcePush = parameters.get(constants.getForcePushKey());
+        OverwriteMode overwriteMode = OverwriteMode.FailIfExists;
+        if ("true".equals(forcePush)) {
+          overwriteMode = OverwriteMode.OverwriteExisting;
+        } else if (OverwriteMode.IgnoreIfExists.name().equals(forcePush)) {
+          overwriteMode = OverwriteMode.IgnoreIfExists;
         }
 
-        return new OctopusCommandBuilder() {
-            @Override
-            protected String[] buildCommand(boolean masked) {
-                final ArrayList<String> commands = new ArrayList<String>();
-                final String serverUrl = parameters.get(constants.getServerKey());
-                final String apiKey = parameters.get(constants.getApiKey());
-                final String spaceName = parameters.get(constants.getSpaceName());
-                final String packageIds = parameters.get(constants.getPackageIdKey());
-                final String packageVersion = parameters.get(constants.getPackageVersionKey());
-                final String commandLineArguments = parameters.get(constants.getCommandLineArgumentsKey());
-
-                final String forcePush = parameters.get(constants.getForcePushKey());
-                OverwriteMode overwriteMode = OverwriteMode.FailIfExists;
-                if ("true".equals(forcePush)) {
-                    overwriteMode = OverwriteMode.OverwriteExisting;
-                } else if (OverwriteMode.IgnoreIfExists.name().equals(forcePush)) {
-                    overwriteMode = OverwriteMode.IgnoreIfExists;
-                }
-
-                if (verboseLogging) {
-                    buildLogger.message("ForcePush: " + forcePush);
-                    buildLogger.message("OverwriteMode: " + overwriteMode.name());
-                }
-
-                commands.add("build-information");
-                commands.add("--server");
-                commands.add(serverUrl);
-                commands.add("--apikey");
-                commands.add(masked ? "SECRET" : apiKey);
-
-                if (spaceName != null && !spaceName.isEmpty()) {
-                    commands.add("--space");
-                    commands.add(spaceName);
-                }
-
-                for (String packageId : StringUtil.split(packageIds, "\n")) {
-                    commands.add("--package-id");
-                    commands.add(packageId);
-                }
-
-                commands.add("--version");
-                commands.add(packageVersion);
-
-                commands.add("--file");
-                commands.add(dataFile);
-
-                if (overwriteMode != OverwriteMode.FailIfExists) {
-                    commands.add("--overwrite-mode");
-                    commands.add(overwriteMode.name());
-                }
-
-                if (commandLineArguments != null && !commandLineArguments.isEmpty()) {
-                    commands.addAll(splitSpaceSeparatedValues(commandLineArguments));
-                }
-
-                return commands.toArray(new String[commands.size()]);
-            }
-        };
-    }
-
-    private String createJsonCommitHistory(final Build build) {
-        final List<Change> changes = build.fetchChanges();
-
-        final List<Commit> commits = new ArrayList<>();
-        for (Change change : changes) {
-
-            final Commit c = new Commit();
-            c.Id = change.getVersion();
-            c.Comment = change.getComment();
-
-            commits.add(c);
+        if (verboseLogging) {
+          buildLogger.message("ForcePush: " + forcePush);
+          buildLogger.message("OverwriteMode: " + overwriteMode.name());
         }
 
-        final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
-        return gson.toJson(commits);
+        commands.add("build-information");
+        commands.add("--server");
+        commands.add(serverUrl);
+        commands.add("--apikey");
+        commands.add(masked ? "SECRET" : apiKey);
+
+        if (spaceName != null && !spaceName.isEmpty()) {
+          commands.add("--space");
+          commands.add(spaceName);
+        }
+
+        for (String packageId : StringUtil.split(packageIds, "\n")) {
+          commands.add("--package-id");
+          commands.add(packageId);
+        }
+
+        commands.add("--version");
+        commands.add(packageVersion);
+
+        commands.add("--file");
+        commands.add(dataFile);
+
+        if (overwriteMode != OverwriteMode.FailIfExists) {
+          commands.add("--overwrite-mode");
+          commands.add(overwriteMode.name());
+        }
+
+        if (commandLineArguments != null && !commandLineArguments.isEmpty()) {
+          commands.addAll(splitSpaceSeparatedValues(commandLineArguments));
+        }
+
+        return commands.toArray(new String[commands.size()]);
+      }
+    };
+  }
+
+  private String createJsonCommitHistory(final Build build) {
+    final List<Change> changes = build.fetchChanges();
+
+    final List<Commit> commits = new ArrayList<>();
+    for (Change change : changes) {
+
+      final Commit c = new Commit();
+      c.Id = change.getVersion();
+      c.Comment = change.getComment();
+
+      commits.add(c);
     }
+
+    final Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
+    return gson.toJson(commits);
+  }
 }

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuilder.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusBuildInformationBuilder.java
@@ -15,8 +15,7 @@ public class OctopusBuildInformationBuilder {
       final String vcsCommitNumber,
       final String branch,
       final String commitsJson,
-      final String serverUrl,
-      final String buildId,
+      final String externalBuildUrl,
       final String buildNumber) {
 
     final OctopusBuildInformation buildInformation = new OctopusBuildInformation();
@@ -27,7 +26,7 @@ public class OctopusBuildInformationBuilder {
         gson.fromJson(commitsJson, new TypeToken<List<Commit>>() {}.getType());
     buildInformation.Branch = branch;
     buildInformation.BuildNumber = buildNumber;
-    buildInformation.BuildUrl = serverUrl + "/viewLog.html?buildId=" + buildId;
+    buildInformation.BuildUrl = externalBuildUrl;
     buildInformation.VcsType = vcsType;
     buildInformation.VcsRoot = vcsRoot;
     buildInformation.VcsCommitNumber = vcsCommitNumber;

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
@@ -53,7 +53,7 @@ public class OctopusBuildInformationBuildProcess
 
     final BuildInfoUserData buildInfoUserData = new BuildInfoUserData(parameters);
 
-    final URL buildUrl = constructBuildUrl(sharedConfigParameters.get("externalBuildURL"));
+    final URL buildUrl = constructBuildUrl(sharedConfigParameters.get("externalBuildUrl"));
 
     final BuildInformationUploaderContextBuilder buildInfoBuilder =
         new BuildInformationUploaderContextBuilder()

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
@@ -53,7 +53,13 @@ public class OctopusBuildInformationBuildProcess
 
     final BuildInfoUserData buildInfoUserData = new BuildInfoUserData(parameters);
 
-    final URL buildUrl = constructBuildUrl(sharedConfigParameters.get("externalBuildUrl"));
+    String buildUrlString = sharedConfigParameters.get("externalBuildUrl");
+    if (buildUrlString == null) {
+      // if the Global settings don't have a Server URL then fall back to using the agent's configuration for the server's URL
+      final String buildId = Long.toString(runningBuild.getBuildId());
+      buildUrlString = runningBuild.getAgentConfiguration().getServerUrl() + "/viewLog.html?buildId=" + buildId;
+    }
+    final URL buildUrl = constructBuildUrl(buildUrlString);
 
     final BuildInformationUploaderContextBuilder buildInfoBuilder =
         new BuildInformationUploaderContextBuilder()

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
@@ -55,7 +55,8 @@ public class OctopusBuildInformationBuildProcess
 
     String buildUrlString = sharedConfigParameters.get("externalBuildUrl");
     if (buildUrlString == null) {
-      // if the Global settings don't have a Server URL then fall back to using the agent's configuration for the server's URL
+      // if the Global settings don't have a Server URL then fall back to using the agent's
+      // configuration for the server's URL
       final String buildId = Long.toString(runningBuild.getBuildId());
       buildUrlString = runningBuild.getAgentConfiguration().getServerUrl() + "/viewLog.html?buildId=" + buildId;
     }

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
@@ -52,9 +52,8 @@ public class OctopusBuildInformationBuildProcess
     final Map<String, String> sharedConfigParameters = runningBuild.getSharedConfigParameters();
 
     final BuildInfoUserData buildInfoUserData = new BuildInfoUserData(parameters);
-    final String buildId = Long.toString(runningBuild.getBuildId());
 
-    final URL buildUrl = constructBuildUrl(runningBuild, buildId);
+    final URL buildUrl = constructBuildUrl(sharedConfigParameters.get("externalBuildURL"));
 
     final BuildInformationUploaderContextBuilder buildInfoBuilder =
         new BuildInformationUploaderContextBuilder()
@@ -75,15 +74,13 @@ public class OctopusBuildInformationBuildProcess
         .collect(Collectors.toList());
   }
 
-  private URL constructBuildUrl(final AgentRunningBuild runningBuild, final String buildId)
+  private URL constructBuildUrl(final String externalBuildUrl)
       throws RunBuildException {
 
-    final String buildUrlString =
-        runningBuild.getAgentConfiguration().getServerUrl() + "/viewLog.html?buildId=" + buildId;
     try {
-      return new URL(buildUrlString);
+      return new URL(externalBuildUrl);
     } catch (final MalformedURLException e) {
-      throw new RunBuildException("Failed to construct a build URL from " + buildUrlString, e);
+      throw new RunBuildException("Failed to construct a build URL from " + externalBuildUrl, e);
     }
   }
 

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
@@ -74,8 +74,7 @@ public class OctopusBuildInformationBuildProcess
         .collect(Collectors.toList());
   }
 
-  private URL constructBuildUrl(final String externalBuildUrl)
-      throws RunBuildException {
+  private URL constructBuildUrl(final String externalBuildUrl) throws RunBuildException {
 
     try {
       return new URL(externalBuildUrl);

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcess.java
@@ -58,7 +58,8 @@ public class OctopusBuildInformationBuildProcess
       // if the Global settings don't have a Server URL then fall back to using the agent's
       // configuration for the server's URL
       final String buildId = Long.toString(runningBuild.getBuildId());
-      buildUrlString = runningBuild.getAgentConfiguration().getServerUrl() + "/viewLog.html?buildId=" + buildId;
+      buildUrlString =
+          runningBuild.getAgentConfiguration().getServerUrl() + "/viewLog.html?buildId=" + buildId;
     }
     final URL buildUrl = constructBuildUrl(buildUrlString);
 

--- a/octopus-agent/src/test/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcessTest.java
+++ b/octopus-agent/src/test/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcessTest.java
@@ -63,6 +63,7 @@ class OctopusBuildInformationBuildProcessTest {
     sharedConfigParameters.put("octopus_vcstype", "git");
     sharedConfigParameters.put("vcsroot.url", "git://git.git/git.git");
     sharedConfigParameters.put("build.vcs.number", "COMMIT_HASH");
+    sharedConfigParameters.put("externalBuildUrl", "http://teamcityServer.com/viewLog.html?tab=buildLog&buildId=BuildNumber");
 
     when(mockBuild.getBuildNumber()).thenReturn("BuildNumber");
     when(mockBuild.getSharedConfigParameters()).thenReturn(sharedConfigParameters);

--- a/octopus-agent/src/test/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcessTest.java
+++ b/octopus-agent/src/test/java/octopus/teamcity/agent/buildinformation/OctopusBuildInformationBuildProcessTest.java
@@ -63,7 +63,9 @@ class OctopusBuildInformationBuildProcessTest {
     sharedConfigParameters.put("octopus_vcstype", "git");
     sharedConfigParameters.put("vcsroot.url", "git://git.git/git.git");
     sharedConfigParameters.put("build.vcs.number", "COMMIT_HASH");
-    sharedConfigParameters.put("externalBuildUrl", "http://teamcityServer.com/viewLog.html?tab=buildLog&buildId=BuildNumber");
+    sharedConfigParameters.put(
+        "externalBuildUrl",
+        "http://teamcityServer.com/viewLog.html?tab=buildLog&buildId=BuildNumber");
 
     when(mockBuild.getBuildNumber()).thenReturn("BuildNumber");
     when(mockBuild.getSharedConfigParameters()).thenReturn(sharedConfigParameters);

--- a/octopus-server/src/main/java/octopus/teamcity/server/OctopusBuildInformationBuildStartProcessor.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/OctopusBuildInformationBuildStartProcessor.java
@@ -17,7 +17,8 @@ public class OctopusBuildInformationBuildStartProcessor implements BuildStartCon
   private final Logger logger = Loggers.SERVER;
   private final WebLinks webLinks;
 
-  public OctopusBuildInformationBuildStartProcessor(final ExtensionHolder extensionHolder, final WebLinks webLinks) {
+  public OctopusBuildInformationBuildStartProcessor(
+      final ExtensionHolder extensionHolder, final WebLinks webLinks) {
     extensionHolder.registerExtension(
         BuildStartContextProcessor.class, this.getClass().getName(), this);
     this.webLinks = webLinks;

--- a/octopus-server/src/main/java/octopus/teamcity/server/OctopusBuildInformationBuildStartProcessor.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/OctopusBuildInformationBuildStartProcessor.java
@@ -45,7 +45,7 @@ public class OctopusBuildInformationBuildStartProcessor implements BuildStartCon
           buildStartContext.addSharedParameter("octopus_vcstype", vcsType);
         }
         final String buildUrl = webLinks.getViewLogUrl(buildStartContext.getBuild());
-        buildStartContext.addSharedParameter("externalBuildURL", buildUrl);
+        buildStartContext.addSharedParameter("externalBuildUrl", buildUrl);
       }
     } catch (final Throwable t) {
       logger.error("Failed to write VCS type into the buildstartContext's shared parameters", t);

--- a/octopus-server/src/main/java/octopus/teamcity/server/OctopusBuildInformationBuildStartProcessor.java
+++ b/octopus-server/src/main/java/octopus/teamcity/server/OctopusBuildInformationBuildStartProcessor.java
@@ -8,16 +8,19 @@ import jetbrains.buildServer.log.Loggers;
 import jetbrains.buildServer.serverSide.BuildStartContext;
 import jetbrains.buildServer.serverSide.BuildStartContextProcessor;
 import jetbrains.buildServer.serverSide.SRunningBuild;
+import jetbrains.buildServer.serverSide.WebLinks;
 import jetbrains.buildServer.vcs.VcsRootInstanceEntry;
 import octopus.teamcity.common.OctopusConstants;
 
 public class OctopusBuildInformationBuildStartProcessor implements BuildStartContextProcessor {
 
   private final Logger logger = Loggers.SERVER;
+  private final WebLinks webLinks;
 
-  public OctopusBuildInformationBuildStartProcessor(final ExtensionHolder extensionHolder) {
+  public OctopusBuildInformationBuildStartProcessor(final ExtensionHolder extensionHolder, final WebLinks webLinks) {
     extensionHolder.registerExtension(
         BuildStartContextProcessor.class, this.getClass().getName(), this);
+    this.webLinks = webLinks;
   }
 
   @Override
@@ -40,6 +43,8 @@ public class OctopusBuildInformationBuildStartProcessor implements BuildStartCon
           }
           buildStartContext.addSharedParameter("octopus_vcstype", vcsType);
         }
+        final String buildUrl = webLinks.getViewLogUrl(buildStartContext.getBuild());
+        buildStartContext.addSharedParameter("externalBuildURL", buildUrl);
       }
     } catch (final Throwable t) {
       logger.error("Failed to write VCS type into the buildstartContext's shared parameters", t);


### PR DESCRIPTION
The Build Information is currently being populated with a BuildUrl that is based on the agent's understanding of the TeamCity server's Url. Unfortunately this is not always the same Url you need in order to view the build in the UI, which is why Octopus wants it, to provide a link back to the build page.

This had previously been using the value from the `Administration -> Global Settings -> Server URL` setting, which is what this PR reverts the code back to using.

Fixes #139 