### PR TITLE
fixed git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,3 @@
 * text eol=lf
+*.exe binary
+*.zip binary


### PR DESCRIPTION
The gitattributes needed to explicitly call out the binaries that we have embedded in the repo