### PR TITLE
Remove container cleanup in e2etests

### DIFF
--- a/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
@@ -26,6 +26,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 public class TeamCityFactory {
 
@@ -101,10 +102,9 @@ public class TeamCityFactory {
                 "-Droot.log.level=TRACE -Dteamcity.development.mode=true "
                     + "-Doctopus.enable.step.vnext=true")
             .withStartupTimeout(Duration.ofMinutes(2))
-            .withFileSystemBind(
-                teamCityDataDir.toAbsolutePath().toString(),
-                "/data/teamcity_server/datadir",
-                BindMode.READ_WRITE);
+            .withCopyFileToContainer(
+                MountableFile.forHostPath(teamCityDataDir.toAbsolutePath().toString()),
+                "/data/teamcity_server/datadir");
 
     teamCityServer.start();
     return teamCityServer;

--- a/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
@@ -21,7 +21,6 @@ import org.jetbrains.teamcity.rest.BuildAgent;
 import org.jetbrains.teamcity.rest.TeamCityInstance;
 import org.jetbrains.teamcity.rest.TeamCityInstanceFactory;
 import org.testcontainers.Testcontainers;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;

--- a/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
@@ -95,6 +95,7 @@ public class TeamCityFactory {
             .waitingFor(Wait.forLogMessage(".*Super user authentication token.*", 1))
             .withNetwork(dockerNetwork)
             .withNetworkAliases("server")
+            .withCreateContainerCmdModifier(cmd -> cmd.withUser("1000"))
             .withEnv(
                 "TEAMCITY_SERVER_OPTS",
                 "-Droot.log.level=TRACE -Dteamcity.development.mode=true "

--- a/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/dsl/TeamCityFactory.java
@@ -47,14 +47,7 @@ public class TeamCityFactory {
     final String serverUrl =
         String.format("http://host.testcontainers.internal:%d", octopusServerPort);
     Testcontainers.exposeHostPorts(octopusServerPort);
-    final TeamCityContainers container =
-        createTeamCityServerAndAgent(serverUrl, octopusServerApiKey, projectZipToInstall);
-    try {
-      container.getServerContainer().execInContainer("chmod -R 777 /data/teamcity_server/datadir");
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
-    return container;
+    return createTeamCityServerAndAgent(serverUrl, octopusServerApiKey, projectZipToInstall);
   }
 
   // When OctopusServer's URL can be fully specified

--- a/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
@@ -113,10 +113,6 @@ public class BuildInformationEndToEndTest {
       LOG.info("Failed to execute build");
       LOG.info(teamCityContainers.getAgentContainer().getLogs());
       throw e;
-    } finally {
-      // Turns out, some files get written to this directory by TC (as the tcuser) - and they need
-      // to be destroyed.
-      cleanupContainers(teamCityContainers);
     }
   }
 
@@ -135,27 +131,5 @@ public class BuildInformationEndToEndTest {
     }
     LOG.warn("Build {} failed to complete within expected time limit", build.getId());
     throw new RuntimeException("Build Failed to complete within 30 seconds");
-  }
-
-  private void cleanupContainers(final TeamCityContainers teamCityContainers) {
-    final List<String> filesToDelete =
-        Lists.newArrayList(
-            "/data/teamcity_server/datadir/system/buildserver.tmp",
-            "/data/teamcity_server/datadir/system/artifacts",
-            "/data/teamcity_server/datadir/system/caches/plugins.unpacked",
-            "/data/teamcity_server/datadir/system/caches/pluginsDslCache/src",
-            "/data/teamcity_server/datadir/system/caches/buildsMetadata/metadataDB.tmp",
-            "/data/teamcity_server/datadir/system/caches/sources",
-            "/data/teamcity_server/datadir/system/caches/kotlinDslData",
-            "/data/teamcity_server/datadir/system/pluginData/avatars");
-
-    for (final String file : filesToDelete) {
-      try {
-        LOG.debug("Removing " + file);
-        teamCityContainers.getServerContainer().execInContainer("rm", "-rf", file);
-      } catch (final Exception e) {
-        LOG.error("Failed to delete " + file);
-      }
-    }
   }
 }

--- a/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
@@ -112,10 +112,6 @@ public class BuildInformationEndToEndTest {
       LOG.info("Failed to execute build");
       LOG.info(teamCityContainers.getAgentContainer().getLogs());
       throw e;
-    } finally {
-      teamCityContainers
-          .getServerContainer()
-          .execInContainer("chmod -R 777 /data/teamcity_server/datadir");
     }
   }
 

--- a/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
@@ -113,7 +113,9 @@ public class BuildInformationEndToEndTest {
       LOG.info(teamCityContainers.getAgentContainer().getLogs());
       throw e;
     } finally {
-      teamCityContainers.getServerContainer().execInContainer("chmod -R 777 /data/teamcity_server/datadir");
+      teamCityContainers
+          .getServerContainer()
+          .execInContainer("chmod -R 777 /data/teamcity_server/datadir");
     }
   }
 

--- a/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
@@ -112,6 +112,8 @@ public class BuildInformationEndToEndTest {
       LOG.info("Failed to execute build");
       LOG.info(teamCityContainers.getAgentContainer().getLogs());
       throw e;
+    } finally {
+      teamCityContainers.getServerContainer().execInContainer("chmod -R 777 /data/teamcity_server/datadir");
     }
   }
 

--- a/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
+++ b/e2e/src/test/java/octopus/teamcity/e2e/test/BuildInformationEndToEndTest.java
@@ -29,7 +29,6 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 
-import com.google.common.collect.Lists;
 import com.google.common.io.Resources;
 import octopus.teamcity.e2e.dsl.TeamCityContainers;
 import octopus.teamcity.e2e.dsl.TeamCityFactory;


### PR DESCRIPTION
Prior to explicitly setting the user which runs the TC containers, the tests were required to clean up "left over files" created by the container, prior to junit removing the tempdirectory (and failing due to permissions).

Now that the UserId in the container is the same as that executing the test, this cleanup is no longer required, as no permissioning conflict exists.