### PR TITLE
Use new Octopus OICD auth for pushing TC artifacts during build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,12 +50,6 @@ jobs:
 
     - name: Call GitVersion
       uses: gittools/actions/gitversion/execute@v0.9.13
-
-    - name: Login to Octopus
-      uses: OctopusDeploy/login@v1
-      with:
-        server: ${{ secrets.OCTOPUS_SERVER }}
-        service_account_id: 7dd778e4-c37d-4b45-a4c4-4d6c7442d180
         
     - name: Determine Version
       id: git-version
@@ -84,13 +78,17 @@ jobs:
         name: Octopus.TeamCity.${{ steps.git-version.outputs.nugetVersion }}
         path: '${{ steps.create-package.outputs.package-created }}'
 
-    #- name: Execute end-2-end tests
-    #  run: ./gradlew e2etest -Pversion=${{ steps.git-version.outputs.nugetVersion }}
-    #  env:
-    #    OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
-    #    OCTOPUS_SDK_AT_USE_EXISTING_SERVER: false
+    - name: Execute end-2-end tests
+      run: ./gradlew e2etest -Pversion=${{ steps.git-version.outputs.nugetVersion }}
+      env:
+        OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
+        OCTOPUS_SDK_AT_USE_EXISTING_SERVER: false
 
-
+    - name: Login to Octopus
+      uses: OctopusDeploy/login@v1
+      with:
+        server: ${{ secrets.OCTOPUS_SERVER }}
+        service_account_id: ${{ vars.OCTOPUS_SERVICE_ACCOUNT }}
         
     - name: Push build information 🐙
       uses: OctopusDeploy/push-build-information-action@v3
@@ -115,9 +113,9 @@ jobs:
         jq --raw-output '.release.body' ${{ github.event_path }} | sed 's#\r#  #g' > $OUTPUT_FILE
         echo "::set-output name=release-note-file::$OUTPUT_FILE"
 
-   # - name: Create a release in Octopus Deploy 🐙
-   #   uses: OctopusDeploy/create-release-action@v3
-   #   with:
-   #     project: 'TeamCity Plugin'
-   #     package_version: ${{ steps.git-version.outputs.nugetVersion }}
-   #     release_notes_file: ${{ steps.fetch-release-notes.outputs.release-note-file }}
+    - name: Create a release in Octopus Deploy 🐙
+      uses: OctopusDeploy/create-release-action@v3
+      with:
+        project: 'TeamCity Plugin'
+        package_version: ${{ steps.git-version.outputs.nugetVersion }}
+        release_notes_file: ${{ steps.fetch-release-notes.outputs.release-note-file }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,7 +88,7 @@ jobs:
         service_account_id: 7dd778e4-c37d-4b45-a4c4-4d6c7442d180
         
     - name: Push build information 🐙
-      uses: OctopusDeploy/push-build-information-action@v2
+      uses: OctopusDeploy/push-build-information-action@v3
       with:
         packages: 'Octopus.TeamCity'
         version: ${{ steps.git-version.outputs.nugetVersion }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,6 @@ jobs:
     # conditionally skip build on PR merge of release-please, because the release creation is going to trigger the real build
     if: ${{ github.ref_name != 'main' || github.event.head_commit.author.username != 'team-integrations-fnm-bot' }}
     env:
-      OCTOPUS_API_KEY: ${{ secrets.OCTOPUS_APIKEY }}
       OCTOPUS_HOST: ${{ secrets.OCTOPUS_SERVER }}
       OCTOPUS_SPACE: Integrations
 
@@ -91,8 +90,14 @@ jobs:
     - name: Install Octopus CLI 🐙
       uses: OctopusDeploy/install-octopus-cli-action@v1
 
+    - name: Login to Octopus
+      uses: OctopusDeploy/login@v1
+      with:
+        server: ${{ secrets.OCTOPUS_SERVER }}
+        service_account_id: 7dd778e4-c37d-4b45-a4c4-4d6c7442d180
+        
     - name: Push a package to Octopus Deploy 🐙
-      uses: OctopusDeploy/push-package-action@v2
+      uses: OctopusDeploy/push-package-action@v3
       with:
         packages: '${{ steps.create-package.outputs.package-created }}'
 
@@ -106,7 +111,7 @@ jobs:
         echo "::set-output name=release-note-file::$OUTPUT_FILE"
 
     - name: Create a release in Octopus Deploy 🐙
-      uses: OctopusDeploy/create-release-action@v2
+      uses: OctopusDeploy/create-release-action@v3
       with:
         project: 'TeamCity Plugin'
         package_version: ${{ steps.git-version.outputs.nugetVersion }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  
 jobs:
   build:
     name: "Build and Package"
@@ -48,6 +51,12 @@ jobs:
     - name: Call GitVersion
       uses: gittools/actions/gitversion/execute@v0.9.13
 
+    - name: Login to Octopus
+      uses: OctopusDeploy/login@v1
+      with:
+        server: ${{ secrets.OCTOPUS_SERVER }}
+        service_account_id: 7dd778e4-c37d-4b45-a4c4-4d6c7442d180
+        
     - name: Determine Version
       id: git-version
       run: |
@@ -81,11 +90,7 @@ jobs:
     #    OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
     #    OCTOPUS_SDK_AT_USE_EXISTING_SERVER: false
 
-    - name: Login to Octopus
-      uses: OctopusDeploy/login@v1
-      with:
-        server: ${{ secrets.OCTOPUS_SERVER }}
-        service_account_id: 7dd778e4-c37d-4b45-a4c4-4d6c7442d180
+
         
     - name: Push build information 🐙
       uses: OctopusDeploy/push-build-information-action@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,26 +75,26 @@ jobs:
         name: Octopus.TeamCity.${{ steps.git-version.outputs.nugetVersion }}
         path: '${{ steps.create-package.outputs.package-created }}'
 
-    - name: Execute end-2-end tests
-      run: ./gradlew e2etest -Pversion=${{ steps.git-version.outputs.nugetVersion }}
-      env:
-        OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
-        OCTOPUS_SDK_AT_USE_EXISTING_SERVER: false
-     
-    - name: Push build information 🐙
-      uses: OctopusDeploy/push-build-information-action@v1
-      with:
-        packages: 'Octopus.TeamCity'
-        version: ${{ steps.git-version.outputs.nugetVersion }}
-
-    - name: Install Octopus CLI 🐙
-      uses: OctopusDeploy/install-octopus-cli-action@v1
+    #- name: Execute end-2-end tests
+    #  run: ./gradlew e2etest -Pversion=${{ steps.git-version.outputs.nugetVersion }}
+    #  env:
+    #    OCTOPUS_LICENSE: ${{ secrets.OCTOPUS_LICENSE }}
+    #    OCTOPUS_SDK_AT_USE_EXISTING_SERVER: false
 
     - name: Login to Octopus
       uses: OctopusDeploy/login@v1
       with:
         server: ${{ secrets.OCTOPUS_SERVER }}
         service_account_id: 7dd778e4-c37d-4b45-a4c4-4d6c7442d180
+        
+    - name: Push build information 🐙
+      uses: OctopusDeploy/push-build-information-action@v2
+      with:
+        packages: 'Octopus.TeamCity'
+        version: ${{ steps.git-version.outputs.nugetVersion }}
+
+    - name: Install Octopus CLI 🐙
+      uses: OctopusDeploy/install-octopus-cli-action@v1
         
     - name: Push a package to Octopus Deploy 🐙
       uses: OctopusDeploy/push-package-action@v3
@@ -110,9 +110,9 @@ jobs:
         jq --raw-output '.release.body' ${{ github.event_path }} | sed 's#\r#  #g' > $OUTPUT_FILE
         echo "::set-output name=release-note-file::$OUTPUT_FILE"
 
-    - name: Create a release in Octopus Deploy 🐙
-      uses: OctopusDeploy/create-release-action@v3
-      with:
-        project: 'TeamCity Plugin'
-        package_version: ${{ steps.git-version.outputs.nugetVersion }}
-        release_notes_file: ${{ steps.fetch-release-notes.outputs.release-note-file }}
+   # - name: Create a release in Octopus Deploy 🐙
+   #   uses: OctopusDeploy/create-release-action@v3
+   #   with:
+   #     project: 'TeamCity Plugin'
+   #     package_version: ${{ steps.git-version.outputs.nugetVersion }}
+   #     release_notes_file: ${{ steps.fetch-release-notes.outputs.release-note-file }}


### PR DESCRIPTION
Rather than faf about with key rotations, use OICD auth