### PR TITLE
Fixing variable typo

### DIFF
--- a/octopus-common/src/main/java/octopus/teamcity/common/OctopusConstants.java
+++ b/octopus-common/src/main/java/octopus/teamcity/common/OctopusConstants.java
@@ -86,11 +86,11 @@ public class OctopusConstants {
   }
 
   public String getTenantsKey() {
-    return "octoups_tenants";
+    return "octopus_tenants";
   }
 
   public String getTenantTagsKey() {
-    return "octoups_tenanttags";
+    return "octopus_tenanttags";
   }
 
   public String getPackageIdKey() {


### PR DESCRIPTION
These typos generate confusion specially while working with Configuration as Code in TeamCity