### PR TITLE
fix: classify Octopus Cloud maintenance response as transient

### DIFF
--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusErrorClassifier.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusErrorClassifier.java
@@ -25,8 +25,11 @@ import java.util.regex.Pattern;
  *
  * <p>Both the legacy .NET CLI (octo.dll) and the Go CLI (octopus) produce different error messages
  * for the same failure modes, so patterns cover both formats: - .NET: "The remote server returned
- * an error: (502)" / "Unable to connect to the remote server" - Go: "server returned HTTP status
- * 502" / "connection refused" / "i/o timeout"
+ * an error: (502)" / "Unable to connect to .*server" - Go: "server returned HTTP status 502" /
+ * "connection refused" / "i/o timeout"
+ *
+ * <p>Also handles the case where Octopus Cloud returns a maintenance HTML page (which masks the
+ * underlying HTTP 503 from octo.dll) by matching "undergoing maintenance" anywhere in the body.
  *
  * <p>Classification priority: permanent patterns are checked first. If neither matches, the error
  * is treated as permanent (fail-safe: unknown errors are not retried).
@@ -42,7 +45,7 @@ public class OctopusErrorClassifier {
 
   private static final List<Pattern> TRANSIENT_PATTERNS =
       Arrays.asList(
-          Pattern.compile("Unable to connect to the remote server", Pattern.CASE_INSENSITIVE),
+          Pattern.compile("Unable to connect to .*server", Pattern.CASE_INSENSITIVE),
           Pattern.compile(
               "The remote server returned an error: \\(50[234]\\)", Pattern.CASE_INSENSITIVE),
           Pattern.compile("The remote name could not be resolved", Pattern.CASE_INSENSITIVE),
@@ -52,7 +55,8 @@ public class OctopusErrorClassifier {
           Pattern.compile("i/o timeout", Pattern.CASE_INSENSITIVE),
           Pattern.compile("no such host", Pattern.CASE_INSENSITIVE),
           Pattern.compile("server returned HTTP status 50[234]", Pattern.CASE_INSENSITIVE),
-          Pattern.compile("The Octopus server .* is not available", Pattern.CASE_INSENSITIVE));
+          Pattern.compile("The Octopus server .* is not available", Pattern.CASE_INSENSITIVE),
+          Pattern.compile("undergoing maintenance", Pattern.CASE_INSENSITIVE));
 
   private static final List<Pattern> PERMANENT_PATTERNS =
       Arrays.asList(

--- a/octopus-agent/src/test/java/octopus/teamcity/agent/OctopusErrorClassifierTest.java
+++ b/octopus-agent/src/test/java/octopus/teamcity/agent/OctopusErrorClassifierTest.java
@@ -63,10 +63,33 @@ class OctopusErrorClassifierTest {
         "server returned HTTP status 502",
         "server returned HTTP status 503",
         "server returned HTTP status 504",
-        "The Octopus server https://octopus.example.com is not available"
+        "The Octopus server https://octopus.example.com is not available",
+        "Unable to connect to the Octopus Deploy server",
+        "Octopus Cloud instance is Undergoing Maintenance",
+        "Your Octopus Cloud instance is currently undergoing maintenance and will be back soon."
       })
   void transientPatternsAreClassifiedCorrectly(String output) {
     assertThat(OctopusErrorClassifier.classify(1, output)).isEqualTo(ErrorCategory.TRANSIENT);
+  }
+
+  @Test
+  void octoDllMaintenancePageIsTransient() {
+    String output =
+        "System.Exception: Unable to connect to the Octopus Deploy server. "
+            + "See the inner exception for details.\n"
+            + " ---> Octopus.Client.Exceptions.OctopusServerException: <!DOCTYPE html>\n"
+            + "<html>\n"
+            + "  <head>\n"
+            + "    <title>Octopus Cloud instance is Undergoing Maintenance</title>\n"
+            + "  </head>\n"
+            + "  <body>\n"
+            + "    <h2>Octopus Cloud instance is Undergoing Maintenance</h2>\n"
+            + "    <p>Your Octopus Cloud instance is currently undergoing maintenance "
+            + "and will be back soon.</p>\n"
+            + "  </body>\n"
+            + "</html>\n"
+            + "Exit code: -3";
+    assertThat(OctopusErrorClassifier.classify(253, output)).isEqualTo(ErrorCategory.TRANSIENT);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Summary

- Broaden `OctopusErrorClassifier`'s connect-error pattern from `"Unable to connect to the remote server"` to `"Unable to connect to .*server"`, so it also matches octo.dll's wrapper wording `"Unable to connect to the Octopus Deploy server"`.
- Add `"undergoing maintenance"` (case-insensitive) as a transient pattern, so an Octopus Cloud maintenance HTML response is classified as transient even when octo.dll has masked the underlying HTTP 503.

## Why

The retry executor introduced in #186 did not retry when Octopus Cloud was in its scheduled maintenance window on 2026-05-18 (see build [22448351](https://build.octopushq.com/buildConfiguration/OctopusDeploy_OctopusServer_FrontEnd_BuildAndPublishPortalShowcaseLanding/22448351), step 2/4 "Push component showcase terraform package").

The CLI output for that build was:

```
System.Exception: Unable to connect to the Octopus Deploy server. See the inner exception for details.
 ---> Octopus.Client.Exceptions.OctopusServerException: <!DOCTYPE html>
 ...
    <title>Octopus Cloud instance is Undergoing Maintenance</title>
 ...
    Your Octopus Cloud instance is currently undergoing maintenance and will be back soon.
 ...
Exit code: -3
```

Walking the existing `TRANSIENT_PATTERNS`:

- `"Unable to connect to the remote server"` — does not match. octo.dll's own wrapper says `"Octopus Deploy server"`, not `"remote server"` (the System.Net.WebException wording).
- `"The remote server returned an error: \\(50[234]\\)"` and `"server returned HTTP status 50[234]"` — do not match. The HTTP 503 is never plain-text in the CLI output when the response body is HTML; only the HTML body and a generic stack trace are surfaced.
- All other transient patterns (`connection refused`, `i/o timeout`, etc.) — do not match.

So `classify(...)` fell through to its `PERMANENT` fail-safe and `OctopusCliRetryExecutor` returned without retrying.

The PR #186 manual test simulated the server being down via an unreachable IP, which produces a different (TCP-level) error string that *does* match `"Unable to connect to the remote server"`. That test path didn't cover the Octopus Cloud maintenance path.

## Test plan

- [x] Added 3 new parameterized cases + 1 multi-line scenario covering octo.dll's wrapper text and the maintenance HTML body. Verified RED before changing the production code, then GREEN after.
- [x] `./gradlew :octopus-agent:test` — 37/37 `OctopusErrorClassifierTest` cases pass; full module tests pass.
- [x] `./gradlew spotlessCheck` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)