### PR TITLE
feat: Update teamcity-plugin.xml to allow plugin to load on secondary node

### DIFF
--- a/teamcity-plugin.xml
+++ b/teamcity-plugin.xml
@@ -12,5 +12,5 @@
       <url>http://octopusdeploy.com</url>
     </vendor>
   </info>
-  <deployment use-separate-classloader="true" allow-runtime-reload="true" teamcity.development.shadowCopyClasses="true" />
+  <deployment use-separate-classloader="true" allow-runtime-reload="true" teamcity.development.shadowCopyClasses="true" node-responsibilities-aware="true" />
 </teamcity-plugin>


### PR DESCRIPTION
Same #176, but needed due to org secrets not being able to used by outside contributors.