### PR TITLE
fix: include --waitfordeployment when a deployment timeout is set (#195)

### DIFF
--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusCreateReleaseBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusCreateReleaseBuildProcess.java
@@ -94,6 +94,7 @@ public class OctopusCreateReleaseBuildProcess extends OctopusBuildProcess {
 
         if (wait && deployTo != null && !deployTo.isEmpty()) {
           commands.add("--progress");
+          commands.add("--waitfordeployment");
 
           if (deploymentTimeout != null && !deploymentTimeout.isEmpty()) {
             commands.add("--deploymenttimeout");

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusDeployReleaseBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusDeployReleaseBuildProcess.java
@@ -98,6 +98,7 @@ public class OctopusDeployReleaseBuildProcess extends OctopusBuildProcess {
 
         if (wait && deployTo != null && !deployTo.isEmpty()) {
           commands.add("--progress");
+          commands.add("--waitfordeployment");
 
           if (deploymentTimeout != null && !deploymentTimeout.isEmpty()) {
             commands.add("--deploymenttimeout");

--- a/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusPromoteReleaseBuildProcess.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/OctopusPromoteReleaseBuildProcess.java
@@ -85,6 +85,7 @@ public class OctopusPromoteReleaseBuildProcess extends OctopusBuildProcess {
 
         if (wait && deployTo != null && !deployTo.isEmpty()) {
           commands.add("--progress");
+          commands.add("--waitfordeployment");
 
           if (deploymentTimeout != null && !deploymentTimeout.isEmpty()) {
             commands.add("--deploymenttimeout");

--- a/octopus-agent/src/test/java/octopus/teamcity/agent/OctopusDeployReleaseBuildProcessTest.java
+++ b/octopus-agent/src/test/java/octopus/teamcity/agent/OctopusDeployReleaseBuildProcessTest.java
@@ -1,0 +1,45 @@
+package octopus.teamcity.agent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jetbrains.buildServer.agent.AgentRunningBuild;
+import jetbrains.buildServer.agent.BuildProgressLogger;
+import jetbrains.buildServer.agent.BuildRunnerContext;
+import octopus.teamcity.common.OctopusConstants;
+import org.junit.jupiter.api.Test;
+
+class OctopusDeployReleaseBuildProcessTest {
+
+  @Test
+  void buildCommand_includesWaitForDeployment_whenWaitingWithTimeout() {
+    final OctopusConstants constants = OctopusConstants.Instance;
+    Map<String, String> params = new HashMap<>();
+    params.put(constants.getServerKey(), "https://octopus.example.com");
+    params.put(constants.getApiKey(), "API-KEY");
+    params.put(constants.getProjectNameKey(), "MyProject");
+    params.put(constants.getDeployToKey(), "Production");
+    params.put(constants.getWaitForDeployments(), "true");
+    params.put(constants.getDeploymentTimeout(), "00:30:00");
+
+    AgentRunningBuild runningBuild = mock(AgentRunningBuild.class);
+    BuildProgressLogger logger = mock(BuildProgressLogger.class);
+    BuildRunnerContext context = mock(BuildRunnerContext.class);
+    when(context.getRunnerParameters()).thenReturn(params);
+    when(runningBuild.getBuildLogger()).thenReturn(logger);
+
+    OctopusDeployReleaseBuildProcess proc =
+        new OctopusDeployReleaseBuildProcess(runningBuild, context);
+
+    String[] command = proc.createCommand().buildCommand();
+
+    // --deploymenttimeout/--cancelontimeout are silently ignored by the Octopus CLI unless
+    // --waitfordeployment is also passed, so it must be present when waiting on a deployment.
+    assertThat(command).contains("--waitfordeployment");
+    assertThat(command).contains("--deploymenttimeout", "00:30:00");
+  }
+}


### PR DESCRIPTION
## Problem

Fixes #195.

When **"Time to Wait for Deployment"** is set on the *Deploy a Release* step (and the *Create*/*Promote* siblings), the plugin emitted `--progress`, `--deploymenttimeout`, and `--cancelontimeout` — but **never `--waitfordeployment`**. Per the [Octopus CLI docs](https://octopus.com/docs/octopus-rest-api/octopus-cli/deploy-release), `--deploymenttimeout` and `--cancelontimeout` are only honoured when `--waitfordeployment` is also passed, so the configured timeout was silently dropped and the CLI fell back to its 10-minute default.

## Fix

Add `commands.add("--waitfordeployment");` alongside `--progress` in the `wait` block of the three legacy release build processes:

- `OctopusDeployReleaseBuildProcess` (the reported step)
- `OctopusCreateReleaseBuildProcess`
- `OctopusPromoteReleaseBuildProcess`

The new-CLI path (`OCTOPUS_NEW_CLI=true`, `cli/DeployReleaseBuildProcess`) is **unaffected** — it already waits correctly via a separate `octopus … task wait --timeout <value>` command.

## Tests / verification

- Added `OctopusDeployReleaseBuildProcessTest` asserting the built command contains `--waitfordeployment` (and the timeout) when waiting is enabled.
- Verified end-to-end in a dockerised TeamCity 2021.2.3 server+agent running the rebuilt plugin against a local Octopus instance (CLI 9.1.7). The emitted command is now:

  ```
  dotnet octo.dll deploy-release ... --deployto Test --progress --waitfordeployment --deploymenttimeout 00:02:00 --cancelontimeout
  ```

  The agent waited for the deployment to complete and the build succeeded.