### PR TITLE
feat: Add support for TeamCity Connections

### DIFF
--- a/octopus-server/src/main/resources/buildServerResources/editOctopusConnection.jsp
+++ b/octopus-server/src/main/resources/buildServerResources/editOctopusConnection.jsp
@@ -44,7 +44,7 @@
     <props:passwordProperty name="${keys.apiKeyPropertyName}" className="longField"/>
     <span class="error" id="error_${keys.apiKeyPropertyName}"></span>
     <span class="smallNote">
-      Create a <a href="https://octopus.com/docs/security/users-and-teams/service-accounts">service account</a> in the
+      Create a <a href="https://oc.to/service-accounts">service account</a> in the
       Octopus web portal.
     </span>
   </td>


### PR DESCRIPTION
Contains two changes:

- `feat: Add support for TeamCity Connections` — marker commit for the connections feature.
- `docs: use the oc.to short link for the service accounts help link` — the connection dialog's "service account" help link now points at `https://oc.to/service-accounts` instead of the long `octopus.com/docs/...` URL.
