### PR TITLE
fix: new Octopus CLI extraction failing on windows agents

### DIFF
--- a/octopus-agent/src/main/java/octopus/teamcity/agent/EmbeddedResourceExtractor.java
+++ b/octopus-agent/src/main/java/octopus/teamcity/agent/EmbeddedResourceExtractor.java
@@ -133,9 +133,15 @@ public class EmbeddedResourceExtractor {
       throws Exception {
     String binaryArchive =
         getArchiveName(String.format("resources/newcli/%s/%s", octopusVersion, osFolder));
-    extractTarGzResource(
-        String.format("/resources/newcli/%s/%s/%s", octopusVersion, osFolder, binaryArchive),
-        Paths.get(destinationPath));
+    String resourcePath =
+        String.format("/resources/newcli/%s/%s/%s", octopusVersion, osFolder, binaryArchive);
+    Path destDir = Paths.get(destinationPath);
+
+    if (binaryArchive.endsWith(".zip")) {
+      extractZipResource(resourcePath, destDir);
+    } else {
+      extractTarGzResource(resourcePath, destDir);
+    }
   }
 
   public void extractTarGzResource(String resourcePath, Path destDir) throws IOException {
@@ -173,6 +179,46 @@ public class EmbeddedResourceExtractor {
               }
             }
           }
+        }
+      }
+    }
+  }
+
+  public void extractZipResource(String resourcePath, Path destDir) throws IOException {
+    Files.createDirectories(destDir);
+    Path realDestDir = destDir.toRealPath();
+
+    try (InputStream fi = getClass().getResourceAsStream(resourcePath)) {
+      if (fi == null) {
+        throw new IOException("Resource not found: " + resourcePath);
+      }
+
+      try (BufferedInputStream bi = new BufferedInputStream(fi);
+          ZipInputStream zipIn = new ZipInputStream(bi)) {
+
+        ZipEntry entry;
+        byte[] buffer = new byte[4096];
+        while ((entry = zipIn.getNextEntry()) != null) {
+          Path entryPath = realDestDir.resolve(entry.getName()).normalize();
+
+          if (!entryPath.startsWith(realDestDir)) {
+            throw new IOException(
+                "Zip Slip detected! Entry is outside of the target directory: " + entry.getName());
+          }
+
+          if (entry.isDirectory()) {
+            Files.createDirectories(entryPath);
+          } else {
+            Files.createDirectories(entryPath.getParent());
+
+            try (OutputStream out = Files.newOutputStream(entryPath)) {
+              int bytesRead;
+              while ((bytesRead = zipIn.read(buffer)) != -1) {
+                out.write(buffer, 0, bytesRead);
+              }
+            }
+          }
+          zipIn.closeEntry();
         }
       }
     }

--- a/octopus-agent/src/test/java/octopus/teamcity/agent/EmbeddedResourceExtractorTest.java
+++ b/octopus-agent/src/test/java/octopus/teamcity/agent/EmbeddedResourceExtractorTest.java
@@ -9,6 +9,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.zip.GZIPOutputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -49,6 +51,43 @@ class EmbeddedResourceExtractorTest {
     // resourcePath must start with '/'
     String resourcePath = "/test-extract/archive-cls.tar.gz";
     extractor.extractTarGzResource(resourcePath, destDir);
+
+    Path extracted = destDir.resolve("dir").resolve("hello.txt");
+    assertThat(Files.exists(extracted)).isTrue();
+    String read = new String(Files.readAllBytes(extracted), StandardCharsets.UTF_8);
+    assertThat(read).isEqualTo("hello-from-classpath");
+  }
+
+  @Test
+  void extractZipResource_readsFromClasspathResource() throws Exception {
+    // locate classpath root
+    URL root = this.getClass().getClassLoader().getResource("");
+    if (root == null) {
+      throw new IllegalStateException("Unable to locate test classpath root");
+    }
+
+    Path resourceRoot = Paths.get(root.toURI());
+    Path folder = resourceRoot.resolve("test-extract");
+    Files.createDirectories(folder);
+
+    Path archivePath = folder.resolve("archive-cls.zip");
+
+    byte[] content = "hello-from-classpath".getBytes(StandardCharsets.UTF_8);
+    try (FileOutputStream fos = new FileOutputStream(archivePath.toFile());
+        ZipOutputStream zos = new ZipOutputStream(fos)) {
+
+      ZipEntry entry = new ZipEntry("dir/hello.txt");
+      zos.putNextEntry(entry);
+      zos.write(content);
+      zos.closeEntry();
+    }
+
+    EmbeddedResourceExtractor extractor = new EmbeddedResourceExtractor();
+    Path destDir = Files.createTempDirectory("extract-target-cls-zip-");
+
+    // resourcePath must start with '/'
+    String resourcePath = "/test-extract/archive-cls.zip";
+    extractor.extractZipResource(resourcePath, destDir);
 
     Path extracted = destDir.resolve("dir").resolve("hello.txt");
     assertThat(Files.exists(extracted)).isTrue();


### PR DESCRIPTION
Fixes HPY-1545.

Fixes https://github.com/OctopusDeploy/Octopus-TeamCity/issues/214.

The new CLI is failing on Windows agents due to a disconnect between how the CLI is packaged and how it's extracted: Windows ships as `.zip` but is being extracted as a tarball, causing a fatal error. 

Adds `extractZipResource`, mirroring the existing `extractTarGzResource`, and branches on the archive's actual extension so extraction matches the packaging. Behaviour on Linux/macOS remains unchanged.